### PR TITLE
Add coverage support.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.sw[nop]
 *~
 .cache
+.nyc_output
 .project
 .settings
 TAGS

--- a/test/package.json
+++ b/test/package.json
@@ -4,6 +4,8 @@
   "private": true,
   "scripts": {
     "test": "node --preserve-symlinks test test",
+    "coverage": "nyc --reporter=lcov --reporter=text-summary npm test",
+    "coverage-report": "nyc report --reporter=html --reporter=text-summary",
     "watch": "grunt watch"
   },
   "dependencies": {
@@ -29,5 +31,18 @@
     "grunt": "^1.0.1",
     "jsonld-signatures": "^4.0.0",
     "veres-one-validator": "file:.."
+  },
+  "devDependencies": {
+    "nyc": "^14.1.1"
+  },
+  "nyc": {
+    "include": [
+      "node_modules/veres-one-validator/**"
+    ],
+    "exclude": [
+      "node_modules/veres-one-validator/node_modules/**",
+      "**/test/**"
+    ],
+    "excludeNodeModules": false
   }
 }


### PR DESCRIPTION
- Some coverage support.  A bit tricky to setup with the test dir and symlink setup.
- Not sure what reporters the coverage commands should use.  I just use the html output.  The "text" reporting might be useful too.  And maybe the main test should always run nyc.