### PR TITLE
Update zcap validators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # veres-one-validator ChangeLog
 
+### 8.0.0 - TBD
+
+### Changed
+- **BREAKING**: Validators no longer accept `capabilitionAction` `create` or `update` just `write`.
+
 ## 7.0.0 - 2020-09-30
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 - **BREAKING**: Validators no longer accept `capabilitionAction` `create` or `update` just `write`.
+- **BREAKING**: Validators for proofs require `invocationTarget` is set.
 
 ## 7.0.0 - 2020-09-30
 

--- a/lib/validators/proofs.js
+++ b/lib/validators/proofs.js
@@ -57,7 +57,6 @@ module.exports = async ({basisBlockHeight, ledgerNode, validatorInput}) => {
     }),
     suite: new Ed25519Signature2020(),
   });
-
   if(!result.verified) {
     const error = new BedrockError(
       'Proof verification failed.', 'ValidationError', {

--- a/lib/validators/proofs.js
+++ b/lib/validators/proofs.js
@@ -22,13 +22,11 @@ module.exports = async ({basisBlockHeight, ledgerNode, validatorInput}) => {
 
   switch(validatorInput.type) {
     case 'CreateWebLedgerRecord':
-      // FIXME: change to `write`
-      capabilityAction = 'create';
+      capabilityAction = 'write';
       ({id: expectedTarget} = record);
       break;
     case 'UpdateWebLedgerRecord':
-      // FIXME: change to `write`
-      capabilityAction = 'update';
+      capabilityAction = 'write';
       ({target: expectedTarget} = recordPatch);
       break;
     default:

--- a/lib/validators/proofs.js
+++ b/lib/validators/proofs.js
@@ -51,7 +51,7 @@ module.exports = async ({basisBlockHeight, ledgerNode, validatorInput}) => {
   const result = await jsigs.verify(copy, {
     documentLoader,
     purpose: new CapabilityInvocation({
-      capabilityAction,
+      expectedAction: capabilityAction,
       // controller: record,
       expectedTarget
     }),

--- a/lib/validators/proofs.js
+++ b/lib/validators/proofs.js
@@ -40,13 +40,15 @@ module.exports = async ({basisBlockHeight, ledgerNode, validatorInput}) => {
       return {valid: false, error};
   }
 
-  // FIXME: need to verify accelerator proof, not just DID controller proof
   const documentLoader = helpers.createDidDocumentLoader({
     basisBlockHeight, ledgerNode, record, recordPatch,
     operationType: validatorInput.type
   });
-
-  const result = await jsigs.verify(validatorInput, {
+  // FIXME: need to verify accelerator proof, not just DID controller proof
+  const copy = {...validatorInput};
+  // only verify the last proof for now
+  copy.proof = [copy.proof[copy.proof.length - 1]];
+  const result = await jsigs.verify(copy, {
     documentLoader,
     purpose: new CapabilityInvocation({
       capabilityAction,

--- a/lib/validators/proofs.js
+++ b/lib/validators/proofs.js
@@ -48,7 +48,6 @@ module.exports = async ({basisBlockHeight, ledgerNode, validatorInput}) => {
 
   const result = await jsigs.verify(validatorInput, {
     documentLoader,
-    compactProof: false,
     purpose: new CapabilityInvocation({
       capabilityAction,
       // controller: record,

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@digitalbazaar/zcapld": "^5.0.0",
     "bs58": "^4.0.1",
     "did-context": "^3.0.1",
-    "did-veres-one": "github:veres-one/did-veres-one#v14.x",
+    "did-veres-one": "github:veres-one/did-veres-one#v14-dingo-swap-cap-actions",
     "fast-json-patch": "^2.0.6",
     "jsonld-signatures": "^9.0.0",
     "lodash": "^4.17.11",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@digitalbazaar/ed25519-signature-2020": "^3.0.0",
     "@digitalbazaar/ed25519-verification-key-2020": "^3.1.0",
-    "@digitalbazaar/zcapld": "^3.0.0",
+    "@digitalbazaar/zcapld": "^5.0.0",
     "bs58": "^4.0.1",
     "did-context": "^3.0.1",
     "did-veres-one": "github:veres-one/did-veres-one#v14.x",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@digitalbazaar/zcapld": "^5.0.0",
     "bs58": "^4.0.1",
     "did-context": "^3.0.1",
-    "did-veres-one": "github:veres-one/did-veres-one#v14-dingo-swap-cap-actions",
+    "did-veres-one": "github:veres-one/did-veres-one#v14.x",
     "fast-json-patch": "^2.0.6",
     "jsonld-signatures": "^9.0.0",
     "lodash": "^4.17.11",

--- a/schemas/veres-one-validator.js
+++ b/schemas/veres-one-validator.js
@@ -138,20 +138,27 @@ const publicKey = {
 
 const didDocumentContext = {
   type: 'array',
-  items: {
-    // FIXME: Force first two items to be DID and V1 context?
-    anyOf: [{
+  items: [
+    {
+      // the first context should be the DID Context
       const: constants.DID_CONTEXT_URL
     }, {
+      // the second context should be the V1 Context
       const: constants.VERES_ONE_CONTEXT_V1_URL
     }, {
-      const: constants.WEB_LEDGER_CONTEXT_V1_URL
-    }, {
-      const: constants.ED25519_2020_CONTEXT_V1_URL
-    }, {
-      const: constants.X25519_2020_CONTEXT_V1_URL
-    }]
-  },
+      // the remaining 2 contexts can be any of these
+      anyOf: [{
+        const: constants.DID_CONTEXT_URL
+      }, {
+        const: constants.VERES_ONE_CONTEXT_V1_URL
+      }, {
+        const: constants.WEB_LEDGER_CONTEXT_V1_URL
+      }, {
+        const: constants.ED25519_2020_CONTEXT_V1_URL
+      }, {
+        const: constants.X25519_2020_CONTEXT_V1_URL
+      }]}
+  ],
   maxItems: 4,
   minItems: 2,
 };

--- a/schemas/veres-one-validator.js
+++ b/schemas/veres-one-validator.js
@@ -439,7 +439,7 @@ const baseCapability = {
     capability: {type: 'string'},
     capabilityAction: {
       type: 'string',
-      enum: ['write', 'create', 'update'],
+      enum: ['write'],
     },
     created: schemas.w3cDateTime(),
     creator: {type: 'string'},
@@ -488,7 +488,7 @@ const createCapability = {
     creatorOrVerificationMethod, {
       properties: {
         capabilityAction: {
-          enum: ['create'],
+          enum: ['write'],
         },
       }
     }]
@@ -500,7 +500,7 @@ const updateDidCapability = {
     creatorOrVerificationMethod, {
       properties: {
         capabilityAction: {
-          enum: ['update'],
+          enum: ['write'],
         },
       }
     }]

--- a/schemas/veres-one-validator.js
+++ b/schemas/veres-one-validator.js
@@ -148,10 +148,6 @@ const didDocumentContext = {
     }, {
       // the remaining 2 contexts can be any of these
       anyOf: [{
-        const: constants.DID_CONTEXT_URL
-      }, {
-        const: constants.VERES_ONE_CONTEXT_V1_URL
-      }, {
         const: constants.WEB_LEDGER_CONTEXT_V1_URL
       }, {
         const: constants.ED25519_2020_CONTEXT_V1_URL

--- a/schemas/veres-one-validator.js
+++ b/schemas/veres-one-validator.js
@@ -438,6 +438,7 @@ const baseCapability = {
     'capability',
     'capabilityAction',
     'created',
+    'invocationTarget',
     'proofValue',
     'proofPurpose',
     'type'
@@ -450,6 +451,7 @@ const baseCapability = {
     },
     created: schemas.w3cDateTime(),
     creator: {type: 'string'},
+    invocationTarget: {type: 'string'},
     proofValue: {type: 'string'},
     proofPurpose: {
       type: 'string',

--- a/schemas/veres-one-validator.js
+++ b/schemas/veres-one-validator.js
@@ -489,30 +489,6 @@ const writeCapability = {
     }]
 };
 
-const createCapability = {
-  allOf: [
-    baseCapability,
-    creatorOrVerificationMethod, {
-      properties: {
-        capabilityAction: {
-          enum: ['write'],
-        },
-      }
-    }]
-};
-
-const updateDidCapability = {
-  allOf: [
-    baseCapability,
-    creatorOrVerificationMethod, {
-      properties: {
-        capabilityAction: {
-          enum: ['write'],
-        },
-      }
-    }]
-};
-
 const updateWebLedgerRecord = {
   title: 'Update DID',
   type: 'object',
@@ -536,11 +512,7 @@ const updateWebLedgerRecord = {
     proof: {
       anyOf: [{
         type: 'array',
-        items: [writeCapability, updateDidCapability],
-        additionalItems: false,
-      }, {
-        type: 'array',
-        items: [updateDidCapability, writeCapability],
+        items: [writeCapability, writeCapability],
         additionalItems: false,
       }],
     }
@@ -683,11 +655,7 @@ const createWebLedgerRecord = {
     proof: {
       anyOf: [{
         type: 'array',
-        items: [writeCapability, createCapability],
-        additionalItems: false,
-      }, {
-        type: 'array',
-        items: [createCapability, writeCapability],
+        items: [writeCapability, writeCapability],
         additionalItems: false,
       }],
     },

--- a/test/mocha/05-validate-async.js
+++ b/test/mocha/05-validate-async.js
@@ -43,13 +43,13 @@ describe('validate regular DIDs', () => {
       mockOperation.record = mockDoc;
       // FIXME: add a write proof for the ledger that will pass
       // json-schema validation for testnet v2 *not* a valid signature
-      //mockOperation.proof = clone(mockData.proof);
-      //mockOperation.proof.invocationTarget = mockOperation.record.id;
+      mockOperation.proof = clone(mockData.proof);
+      mockOperation.proof.invocationTarget = mockOperation.record.id;
       const purpose = new CapabilityInvocation({
         capability: did,
         capabilityAction,
         // FIXME this is not making it into the signature
-        invocationTarget: 'SEE ME'
+        invocationTarget: mockDoc.id
       });
       const s = await jsigs.sign(mockOperation, {
         documentLoader,

--- a/test/mocha/05-validate-async.js
+++ b/test/mocha/05-validate-async.js
@@ -529,7 +529,7 @@ describe('validate regular DIDs', () => {
     it('validates an update operation', async () => {
       const {did, mockDoc, capabilityInvocationKey} = await _generateDid();
       const mockOperation = clone(mockData.operations.update);
-      let capabilityAction = 'write';
+      const capabilityAction = 'write';
       // add the new document to the mock document loader as if it were on
       // ledger
       // clone here so we can proceed with making changes to mockDoc
@@ -551,7 +551,6 @@ describe('validate regular DIDs', () => {
       // FIXME: add a write proof for the accelerator that will pass
       // json-schema validation for testnet v2 *not* a valid signature
       mockOperation.proof = clone(mockData.proof);
-      capabilityAction = 'write';
       const s = await jsigs.sign(mockOperation, {
         compactProof: false,
         documentLoader,
@@ -574,7 +573,7 @@ describe('validate regular DIDs', () => {
     it('rejects an update that changes the document ID', async () => {
       const {did, mockDoc, capabilityInvocationKey} = await _generateDid();
       const mockOperation = clone(mockData.operations.update);
-      let capabilityAction = 'write';
+      const capabilityAction = 'write';
       // add the new document to the mock document loader as if it were on
       // ledger
       // clone here so we can proceed with making changes to mockDoc
@@ -600,7 +599,6 @@ describe('validate regular DIDs', () => {
       // FIXME: add a write proof for the accelerator that will pass
       // json-schema validation for testnet v2 *not* a valid signature
       mockOperation.proof = clone(mockData.proof);
-      capabilityAction = 'write';
       const s = await jsigs.sign(mockOperation, {
         compactProof: false,
         documentLoader,
@@ -675,7 +673,7 @@ describe('validate regular DIDs', () => {
     it('rejects an update with an invalid sequence', async () => {
       const {did, mockDoc, capabilityInvocationKey} = await _generateDid();
       const mockOperation = clone(mockData.operations.update);
-      let capabilityAction = 'write';
+      const capabilityAction = 'write';
       // add the new document to the mock document loader as if it were on
       // ledger
       // clone here so we can proceed with making changes to mockDoc
@@ -698,7 +696,6 @@ describe('validate regular DIDs', () => {
       // FIXME: add a write proof for the accelerator that will pass
       // json-schema validation for testnet v2 *not* a valid signature
       mockOperation.proof = clone(mockData.proof);
-      capabilityAction = 'write';
       // specify an invalid sequence
       mockOperation.recordPatch.sequence = 10;
 
@@ -725,7 +722,7 @@ describe('validate regular DIDs', () => {
     it('rejects an update with an invalid patch', async () => {
       const {did, mockDoc, capabilityInvocationKey} = await _generateDid();
       const mockOperation = clone(mockData.operations.update);
-      let capabilityAction = 'write';
+      const capabilityAction = 'write';
       // add the new document to the mock document loader as if it were on
       // ledger
       // clone here so we can proceed with making changes to mockDoc
@@ -748,7 +745,6 @@ describe('validate regular DIDs', () => {
       // FIXME: add a write proof for the accelerator that will pass
       // json-schema validation for testnet v2 *not* a valid signature
       mockOperation.proof = clone(mockData.proof);
-      capabilityAction = 'write';
 
       // specifiy an invalid path to create an invalid JSON patch
       mockOperation.recordPatch.patch[0].path = '/authentication/2';
@@ -777,7 +773,7 @@ describe('validate regular DIDs', () => {
     it('rejects an altered operation', async () => {
       const {did, mockDoc, capabilityInvocationKey} = await _generateDid();
       const mockOperation = clone(mockData.operations.update);
-      let capabilityAction = 'write';
+      const capabilityAction = 'write';
       // add the new document to the mock document loader as if it were on
       // ledger
       // clone here so we can proceed with making changes to mockDoc
@@ -799,7 +795,6 @@ describe('validate regular DIDs', () => {
       // FIXME: add a write proof for the accelerator that will pass
       // json-schema validation for testnet v2 *not* a valid signature
       mockOperation.proof = clone(mockData.proof);
-      capabilityAction = 'write';
       const s = await jsigs.sign(mockOperation, {
         compactProof: false,
         documentLoader,
@@ -837,7 +832,7 @@ describe('validate regular DIDs', () => {
 
       const {did, mockDoc} = await _generateDid();
       const mockOperation = clone(mockData.operations.update);
-      let capabilityAction = 'write';
+      const capabilityAction = 'write';
       // add the new document to the mock document loader as if it were on
       // ledger
       // clone here so we can proceed with making changes to mockDoc
@@ -861,7 +856,6 @@ describe('validate regular DIDs', () => {
       // FIXME: add a write proof for the accelerator that will pass
       // json-schema validation for testnet v2 *not* a valid signature
       mockOperation.proof = clone(mockData.proof);
-      capabilityAction = 'write';
 
       // signing with a key from another valid DID
       const s = await jsigs.sign(mockOperation, {
@@ -895,7 +889,7 @@ describe('validate regular DIDs', () => {
 
       const {did, mockDoc, capabilityInvocationKey} = await _generateDid();
       const mockOperation = clone(mockData.operations.update);
-      let capabilityAction = 'write';
+      const capabilityAction = 'write';
       // add the new document to the mock document loader as if it were on
       // ledger
       // clone here so we can proceed with making changes to mockDoc
@@ -921,7 +915,6 @@ describe('validate regular DIDs', () => {
       // FIXME: add a write proof for the accelerator that will pass
       // json-schema validation for testnet v2 *not* a valid signature
       mockOperation.proof = clone(mockData.proof);
-      capabilityAction = 'write';
 
       // signing with a key from another valid DID
       const s = await jsigs.sign(mockOperation, {
@@ -1051,7 +1044,7 @@ describe('validate regular DIDs', () => {
     it('rejects operation when improper key used in proof 2', async () => {
       const {did, mockDoc, capabilityInvocationKey} = await _generateDid();
       const mockOperation = clone(mockData.operations.update);
-      let capabilityAction = 'write';
+      const capabilityAction = 'write';
       // add the new document to the mock document loader as if it were on
       // ledger
       // clone here so we can proceed with making changes to mockDoc
@@ -1075,7 +1068,6 @@ describe('validate regular DIDs', () => {
       // FIXME: add a write proof for the accelerator that will pass
       // json-schema validation for testnet v2 *not* a valid signature
       mockOperation.proof = clone(mockData.proof);
-      capabilityAction = 'write';
 
       // *must* use `capabilityInvocationKey`
       const s = await jsigs.sign(mockOperation, {
@@ -1109,7 +1101,7 @@ describe('validate regular DIDs', () => {
       const did = didDocument.id;
       const updater = new VeresOneDidDoc({didDocument});
       const mockOperation = clone(mockData.operations.update);
-      let capabilityAction = 'write';
+      const capabilityAction = 'write';
       // add the new document to the mock document loader as if it were on
       // ledger
       // clone here so we can proceed with making changes to mockDoc
@@ -1128,7 +1120,6 @@ describe('validate regular DIDs', () => {
       // add a write proof for the ledger that will pass json-schema
       // validation for testnet v2 *not* a valid signature
       mockOperation.proof = clone(mockData.proof);
-      capabilityAction = 'write';
       const s = await jsigs.sign(mockOperation, {
         compactProof: false,
         documentLoader,
@@ -1159,7 +1150,7 @@ describe('validate regular DIDs', () => {
       const did = didDocument.id;
       const updater = new VeresOneDidDoc({didDocument});
       const mockOperation = clone(mockData.operations.update);
-      let capabilityAction = 'write';
+      const capabilityAction = 'write';
       // add the new document to the mock document loader as if it were on
       // ledger
       // clone here so we can proceed with making changes to mockDoc
@@ -1180,7 +1171,6 @@ describe('validate regular DIDs', () => {
       // add a write proof that will pass json-schema
       // validation for testnet v2 *not* a valid signature
       mockOperation.proof = clone(mockData.proof);
-      capabilityAction = 'write';
       const s = await jsigs.sign(mockOperation, {
         compactProof: false,
         documentLoader,
@@ -1223,7 +1213,7 @@ describe('validate regular DIDs', () => {
         const did = didDocument.id;
         const updater = new VeresOneDidDoc({didDocument});
         const mockOperation = clone(mockData.operations.update);
-        let capabilityAction = 'write';
+        const capabilityAction = 'write';
         mockData.existingDids[did] = clone(didDocument);
 
         updater.observe();
@@ -1244,7 +1234,6 @@ describe('validate regular DIDs', () => {
         // validation for
         // testnet v2 *not* a valid signature
         mockOperation.proof = clone(mockData.proof);
-        capabilityAction = 'write';
         const s = await jsigs.sign(mockOperation, {
           compactProof: false,
           documentLoader,
@@ -1268,7 +1257,7 @@ describe('validate regular DIDs', () => {
         const did = didDocument.id;
         const updater = new VeresOneDidDoc({didDocument});
         const mockOperation = clone(mockData.operations.update);
-        let capabilityAction = 'write';
+        const capabilityAction = 'write';
         mockData.existingDids[did] = clone(didDocument);
 
         updater.observe();
@@ -1295,7 +1284,6 @@ describe('validate regular DIDs', () => {
         // validation for
         // testnet v2 *not* a valid signature
         mockOperation.proof = clone(mockData.proof);
-        capabilityAction = 'write';
         const s = await jsigs.sign(mockOperation, {
           compactProof: false,
           documentLoader,
@@ -1319,7 +1307,7 @@ describe('validate regular DIDs', () => {
         const did = didDocument.id;
         const updater = new VeresOneDidDoc({didDocument});
         const mockOperation = clone(mockData.operations.update);
-        let capabilityAction = 'write';
+        const capabilityAction = 'write';
         mockData.existingDids[did] = clone(didDocument);
 
         updater.observe();
@@ -1340,7 +1328,6 @@ describe('validate regular DIDs', () => {
         // validation for
         // testnet v2 *not* a valid signature
         mockOperation.proof = clone(mockData.proof);
-        capabilityAction = 'write';
         const s = await jsigs.sign(mockOperation, {
           compactProof: false,
           documentLoader,
@@ -1367,7 +1354,7 @@ describe('validate regular DIDs', () => {
         const did = didDocument.id;
         const updater = new VeresOneDidDoc({didDocument});
         const mockOperation = clone(mockData.operations.update);
-        let capabilityAction = 'write';
+        const capabilityAction = 'write';
         mockData.existingDids[did] = clone(didDocument);
 
         updater.observe();
@@ -1388,7 +1375,6 @@ describe('validate regular DIDs', () => {
         // validation for
         // testnet v2 *not* a valid signature
         mockOperation.proof = clone(mockData.proof);
-        capabilityAction = 'write';
         const s = await jsigs.sign(mockOperation, {
           compactProof: false,
           documentLoader,
@@ -1415,7 +1401,7 @@ describe('validate regular DIDs', () => {
         const did = didDocument.id;
         const updater = new VeresOneDidDoc({didDocument});
         const mockOperation = clone(mockData.operations.update);
-        let capabilityAction = 'write';
+        const capabilityAction = 'write';
         mockData.existingDids[did] = clone(didDocument);
 
         updater.observe();
@@ -1442,7 +1428,6 @@ describe('validate regular DIDs', () => {
         // validation for
         // testnet v2 *not* a valid signature
         mockOperation.proof = clone(mockData.proof);
-        capabilityAction = 'write';
         const s = await jsigs.sign(mockOperation, {
           compactProof: false,
           documentLoader,

--- a/test/mocha/05-validate-async.js
+++ b/test/mocha/05-validate-async.js
@@ -44,11 +44,16 @@ describe('validate regular DIDs', () => {
       // FIXME: add a write proof for the ledger that will pass
       // json-schema validation for testnet v2 *not* a valid signature
       mockOperation.proof = clone(mockData.proof);
+      mockOperation.proof.invocationTarget = mockOperation.record.id;
       const s = await jsigs.sign(mockOperation, {
-        compactProof: false,
         documentLoader,
         suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
-        purpose: new CapabilityInvocation({capability: did, capabilityAction})
+        purpose: new CapabilityInvocation({
+          capability: did,
+          capabilityAction,
+          // FIXME this is not making it into the signature
+          invocationTarget: mockDoc.id
+        })
       });
       const result = await voValidator.validate({
         basisBlockHeight: 0,
@@ -70,7 +75,7 @@ describe('validate regular DIDs', () => {
       // json-schema validation for testnet v2 *not* a valid signature
       mockOperation.proof = clone(mockData.proof);
       const s = await jsigs.sign(mockOperation, {
-        compactProof: false,
+
         documentLoader,
         suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
         purpose: new CapabilityInvocation({capability: did, capabilityAction})
@@ -104,7 +109,7 @@ describe('validate regular DIDs', () => {
       // json-schema validation for testnet v2 *not* a valid signature
       mockOperation.proof = clone(mockData.proof);
       const s = await jsigs.sign(mockOperation, {
-        compactProof: false,
+
         documentLoader,
         suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
         purpose: new CapabilityInvocation({capability: did, capabilityAction})
@@ -135,7 +140,7 @@ describe('validate regular DIDs', () => {
       // json-schema validation for testnet v2 *not* a valid signature
       mockOperation.proof = clone(mockData.proof);
       const s = await jsigs.sign(mockOperation, {
-        compactProof: false,
+
         documentLoader,
         suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
         purpose: new CapabilityInvocation({capability: did, capabilityAction})
@@ -165,7 +170,7 @@ describe('validate regular DIDs', () => {
       // json-schema validation for testnet v2 *not* a valid signature
       mockOperation.proof = clone(mockData.proof);
       const s = await jsigs.sign(mockOperation, {
-        compactProof: false,
+
         documentLoader,
         suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
         purpose: new CapabilityInvocation({capability: did, capabilityAction})
@@ -199,7 +204,7 @@ describe('validate regular DIDs', () => {
       // json-schema validation for testnet v2 *not* a valid signature
       mockOperation.proof = clone(mockData.proof);
       const s = await jsigs.sign(mockOperation, {
-        compactProof: false,
+
         documentLoader,
         suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
         purpose: new CapabilityInvocation({capability: did, capabilityAction})
@@ -253,7 +258,7 @@ describe('validate regular DIDs', () => {
         // testnet v2 *not* a valid signature
         mockOperation.proof = clone(mockData.proof);
         const s = await jsigs.sign(mockOperation, {
-          compactProof: false,
+
           documentLoader,
           suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
           purpose: new CapabilityInvocation({capability: did, capabilityAction})
@@ -288,7 +293,7 @@ describe('validate regular DIDs', () => {
         // validation for testnet v2 *not* a valid signature
         mockOperation.proof = clone(mockData.proof);
         const s = await jsigs.sign(mockOperation, {
-          compactProof: false,
+
           documentLoader,
           suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
           purpose: new CapabilityInvocation({capability: did, capabilityAction})
@@ -337,7 +342,7 @@ describe('validate regular DIDs', () => {
         // validation for testnet v2 *not* a valid signature
         mockOperation.proof = clone(mockData.proof);
         const s = await jsigs.sign(mockOperation, {
-          compactProof: false,
+
           documentLoader,
           suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
           purpose: new CapabilityInvocation({capability: did, capabilityAction})
@@ -372,7 +377,7 @@ describe('validate regular DIDs', () => {
         // validation for testnet v2 *not* a valid signature
         mockOperation.proof = clone(mockData.proof);
         const s = await jsigs.sign(mockOperation, {
-          compactProof: false,
+
           documentLoader,
           suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
           purpose: new CapabilityInvocation({capability: did, capabilityAction})
@@ -411,7 +416,7 @@ describe('validate regular DIDs', () => {
         // validation for testnet v2 *not* a valid signature
         mockOperation.proof = clone(mockData.proof);
         const s = await jsigs.sign(mockOperation, {
-          compactProof: false,
+
           documentLoader,
           suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
           purpose: new CapabilityInvocation({capability: did, capabilityAction})
@@ -457,7 +462,7 @@ describe('validate regular DIDs', () => {
         // validation for testnet v2 *not* a valid signature
         mockOperation.proof = clone(mockData.proof);
         const s = await jsigs.sign(mockOperation, {
-          compactProof: false,
+
           documentLoader,
           suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
           purpose: new CapabilityInvocation({capability: did, capabilityAction})
@@ -497,7 +502,7 @@ describe('validate regular DIDs', () => {
         // validation for testnet v2 *not* a valid signature
         mockOperation.proof = clone(mockData.proof);
         const s = await jsigs.sign(mockOperation, {
-          compactProof: false,
+
           documentLoader,
           suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
           purpose: new CapabilityInvocation({capability: did, capabilityAction})
@@ -552,7 +557,7 @@ describe('validate regular DIDs', () => {
       // json-schema validation for testnet v2 *not* a valid signature
       mockOperation.proof = clone(mockData.proof);
       const s = await jsigs.sign(mockOperation, {
-        compactProof: false,
+
         documentLoader,
         suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
         purpose: new CapabilityInvocation({capability: did, capabilityAction})
@@ -600,7 +605,7 @@ describe('validate regular DIDs', () => {
       // json-schema validation for testnet v2 *not* a valid signature
       mockOperation.proof = clone(mockData.proof);
       const s = await jsigs.sign(mockOperation, {
-        compactProof: false,
+
         documentLoader,
         suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
         purpose: new CapabilityInvocation({capability: did, capabilityAction})
@@ -644,7 +649,7 @@ describe('validate regular DIDs', () => {
       // validation for testnet v2 *not* a valid signature
       mockOperation.proof = clone(mockData.proof);
       const s = await jsigs.sign(mockOperation, {
-        compactProof: false,
+
         documentLoader,
         suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
         purpose: new CapabilityInvocation({capability: did, capabilityAction})
@@ -698,7 +703,7 @@ describe('validate regular DIDs', () => {
       mockOperation.recordPatch.sequence = 10;
 
       const s = await jsigs.sign(mockOperation, {
-        compactProof: false,
+
         documentLoader,
         suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
         purpose: new CapabilityInvocation({capability: did, capabilityAction})
@@ -748,7 +753,7 @@ describe('validate regular DIDs', () => {
       mockOperation.recordPatch.patch[0].path = '/authentication/2';
 
       const s = await jsigs.sign(mockOperation, {
-        compactProof: false,
+
         documentLoader,
         suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
         purpose: new CapabilityInvocation({capability: did, capabilityAction})
@@ -794,7 +799,7 @@ describe('validate regular DIDs', () => {
       // json-schema validation for testnet v2 *not* a valid signature
       mockOperation.proof = clone(mockData.proof);
       const s = await jsigs.sign(mockOperation, {
-        compactProof: false,
+
         documentLoader,
         suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
         purpose: new CapabilityInvocation({capability: did, capabilityAction})
@@ -855,7 +860,7 @@ describe('validate regular DIDs', () => {
 
       // signing with a key from another valid DID
       const s = await jsigs.sign(mockOperation, {
-        compactProof: false,
+
         documentLoader,
         suite: new Ed25519Signature2020({key: capabilityInvocationKey1}),
         purpose: new CapabilityInvocation({capability: did, capabilityAction})
@@ -912,7 +917,7 @@ describe('validate regular DIDs', () => {
 
       // signing with a key from another valid DID
       const s = await jsigs.sign(mockOperation, {
-        compactProof: false,
+
         documentLoader,
         suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
         purpose: new CapabilityInvocation({capability: did, capabilityAction})
@@ -962,7 +967,7 @@ describe('validate regular DIDs', () => {
       capabilityAction = 'read';
 
       const s = await jsigs.sign(mockOperation, {
-        compactProof: false,
+
         documentLoader,
         suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
         purpose: new CapabilityInvocation({capability: did, capabilityAction})
@@ -1009,7 +1014,7 @@ describe('validate regular DIDs', () => {
 
       // *must* use `capabilityInvocationKey`
       const s = await jsigs.sign(mockOperation, {
-        compactProof: false,
+
         documentLoader,
         suite: new Ed25519Signature2020({key: newKey}),
         purpose: new CapabilityInvocation({capability: did, capabilityAction})
@@ -1061,7 +1066,7 @@ describe('validate regular DIDs', () => {
 
       // *must* use `capabilityInvocationKey`
       const s = await jsigs.sign(mockOperation, {
-        compactProof: false,
+
         documentLoader,
         suite: new Ed25519Signature2020({key: newKey}),
         purpose: new CapabilityInvocation({capability: did, capabilityAction})
@@ -1107,7 +1112,7 @@ describe('validate regular DIDs', () => {
       // validation for testnet v2 *not* a valid signature
       mockOperation.proof = clone(mockData.proof);
       const s = await jsigs.sign(mockOperation, {
-        compactProof: false,
+
         documentLoader,
         suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
         purpose: new CapabilityInvocation({capability: did, capabilityAction})
@@ -1156,7 +1161,7 @@ describe('validate regular DIDs', () => {
       // validation for testnet v2 *not* a valid signature
       mockOperation.proof = clone(mockData.proof);
       const s = await jsigs.sign(mockOperation, {
-        compactProof: false,
+
         documentLoader,
         suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
         purpose: new CapabilityInvocation({capability: did, capabilityAction})
@@ -1219,7 +1224,7 @@ describe('validate regular DIDs', () => {
         // testnet v2 *not* a valid signature
         mockOperation.proof = clone(mockData.proof);
         const s = await jsigs.sign(mockOperation, {
-          compactProof: false,
+
           documentLoader,
           suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
           purpose: new CapabilityInvocation({capability: did, capabilityAction})
@@ -1269,7 +1274,7 @@ describe('validate regular DIDs', () => {
         // testnet v2 *not* a valid signature
         mockOperation.proof = clone(mockData.proof);
         const s = await jsigs.sign(mockOperation, {
-          compactProof: false,
+
           documentLoader,
           suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
           purpose: new CapabilityInvocation({capability: did, capabilityAction})
@@ -1313,7 +1318,7 @@ describe('validate regular DIDs', () => {
         // testnet v2 *not* a valid signature
         mockOperation.proof = clone(mockData.proof);
         const s = await jsigs.sign(mockOperation, {
-          compactProof: false,
+
           documentLoader,
           suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
           purpose: new CapabilityInvocation({capability: did, capabilityAction})
@@ -1360,7 +1365,7 @@ describe('validate regular DIDs', () => {
         // testnet v2 *not* a valid signature
         mockOperation.proof = clone(mockData.proof);
         const s = await jsigs.sign(mockOperation, {
-          compactProof: false,
+
           documentLoader,
           suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
           purpose: new CapabilityInvocation({capability: did, capabilityAction})
@@ -1413,7 +1418,7 @@ describe('validate regular DIDs', () => {
         // testnet v2 *not* a valid signature
         mockOperation.proof = clone(mockData.proof);
         const s = await jsigs.sign(mockOperation, {
-          compactProof: false,
+
           documentLoader,
           suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
           purpose: new CapabilityInvocation({capability: did, capabilityAction})

--- a/test/mocha/05-validate-async.js
+++ b/test/mocha/05-validate-async.js
@@ -649,8 +649,6 @@ describe('validate regular DIDs', () => {
         suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
         purpose: new CapabilityInvocation({capability: did, capabilityAction})
       });
-      // FIXME this removes the mockData.proof
-      s.proof = [s.proof[1]];
       const result = await voValidator.validate({
         basisBlockHeight: 10,
         ledgerNode: mockData.ledgerNode,
@@ -801,8 +799,6 @@ describe('validate regular DIDs', () => {
         suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
         purpose: new CapabilityInvocation({capability: did, capabilityAction})
       });
-      // remove that proof before validating
-      s.proof = [s.proof[1]];
       // after proof, change the patch target
       const {did: did2} = await _generateDid();
       mockOperation.recordPatch.target = did2;
@@ -864,8 +860,6 @@ describe('validate regular DIDs', () => {
         suite: new Ed25519Signature2020({key: capabilityInvocationKey1}),
         purpose: new CapabilityInvocation({capability: did, capabilityAction})
       });
-      // remove that proof before validating
-      s.proof = [s.proof[1]];
       const result = await voValidator.validate({
         basisBlockHeight: 10,
         ledgerNode: mockData.ledgerNode,
@@ -923,8 +917,6 @@ describe('validate regular DIDs', () => {
         suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
         purpose: new CapabilityInvocation({capability: did, capabilityAction})
       });
-      // remove that proof before validating
-      s.proof = [s.proof[1]];
       const result = await voValidator.validate({
         basisBlockHeight: 10,
         ledgerNode: mockData.ledgerNode,
@@ -1022,8 +1014,6 @@ describe('validate regular DIDs', () => {
         suite: new Ed25519Signature2020({key: newKey}),
         purpose: new CapabilityInvocation({capability: did, capabilityAction})
       });
-      // remove that proof before validating
-      s.proof = [s.proof[1]];
       const result = await voValidator.validate({
         basisBlockHeight: 10,
         ledgerNode: mockData.ledgerNode,
@@ -1076,8 +1066,6 @@ describe('validate regular DIDs', () => {
         suite: new Ed25519Signature2020({key: newKey}),
         purpose: new CapabilityInvocation({capability: did, capabilityAction})
       });
-      // remove that proof before validating
-      s.proof = [s.proof[1]];
       const result = await voValidator.validate({
         basisBlockHeight: 10,
         ledgerNode: mockData.ledgerNode,

--- a/test/mocha/05-validate-async.js
+++ b/test/mocha/05-validate-async.js
@@ -646,7 +646,7 @@ console.log(JSON.stringify(result, null, 2));
       // add an AuthorizeRequest proof that will pass json-schema validation for
       // testnet v2 *not* a valid signature
       mockOperation.proof = clone(mockData.proof);
-      capabilityAction = 'update';
+      capabilityAction = 'write';
       const s = await jsigs.sign(mockOperation, {
         compactProof: false,
         documentLoader,

--- a/test/mocha/05-validate-async.js
+++ b/test/mocha/05-validate-async.js
@@ -43,17 +43,18 @@ describe('validate regular DIDs', () => {
       mockOperation.record = mockDoc;
       // FIXME: add a write proof for the ledger that will pass
       // json-schema validation for testnet v2 *not* a valid signature
-      mockOperation.proof = clone(mockData.proof);
-      mockOperation.proof.invocationTarget = mockOperation.record.id;
+      //mockOperation.proof = clone(mockData.proof);
+      //mockOperation.proof.invocationTarget = mockOperation.record.id;
+      const purpose = new CapabilityInvocation({
+        capability: did,
+        capabilityAction,
+        // FIXME this is not making it into the signature
+        invocationTarget: 'SEE ME'
+      });
       const s = await jsigs.sign(mockOperation, {
         documentLoader,
         suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
-        purpose: new CapabilityInvocation({
-          capability: did,
-          capabilityAction,
-          // FIXME this is not making it into the signature
-          invocationTarget: mockDoc.id
-        })
+        purpose
       });
       const result = await voValidator.validate({
         basisBlockHeight: 0,

--- a/test/mocha/05-validate-async.js
+++ b/test/mocha/05-validate-async.js
@@ -39,10 +39,10 @@ describe('validate regular DIDs', () => {
     it('validates a proper CreateWebLedgerRecord operation', async () => {
       const {did, mockDoc, capabilityInvocationKey} = await _generateDid();
       const mockOperation = clone(mockData.operations.create);
-      const capabilityAction = 'create';
+      const capabilityAction = 'write';
       mockOperation.record = mockDoc;
-      // FIXME: add an AuthorizeRequest proof that will pass json-schema
-      // validation for testnet v2 *not* a valid signature
+      // FIXME: add a write proof for the ledger that will pass
+      // json-schema validation for testnet v2 *not* a valid signature
       mockOperation.proof = clone(mockData.proof);
       const s = await jsigs.sign(mockOperation, {
         compactProof: false,
@@ -58,16 +58,17 @@ describe('validate regular DIDs', () => {
           .operationValidator[0],
       });
       should.exist(result);
+console.log(JSON.stringify(result, null, 2));
       result.valid.should.be.a('boolean');
       result.valid.should.be.true;
     });
     it('throws on CreateWebLedgerRecord without basisBlockHeight', async () => {
       const {did, mockDoc, capabilityInvocationKey} = await _generateDid();
       const mockOperation = clone(mockData.operations.create);
-      const capabilityAction = 'create';
+      const capabilityAction = 'write';
       mockOperation.record = mockDoc;
-      // FIXME: add an AuthorizeRequest proof that will pass json-schema
-      // validation for testnet v2 *not* a valid signature
+      // FIXME: add a write proof for the accelerator that will pass
+      // json-schema validation for testnet v2 *not* a valid signature
       mockOperation.proof = clone(mockData.proof);
       const s = await jsigs.sign(mockOperation, {
         compactProof: false,
@@ -98,10 +99,10 @@ describe('validate regular DIDs', () => {
       const capabilityInvocationKey =
         mockDoc.methodFor({purpose: 'capabilityInvocation'});
       const mockOperation = clone(mockData.operations.create);
-      const capabilityAction = 'create';
+      const capabilityAction = 'write';
       mockOperation.record = mockDoc.didDocument;
-      // add an AuthorizeRequest proof that will pass json-schema validation for
-      // testnet v2 *not* a valid signature
+      // FIXME: add a write proof for the accelerator that will pass
+      // json-schema validation for testnet v2 *not* a valid signature
       mockOperation.proof = clone(mockData.proof);
       const s = await jsigs.sign(mockOperation, {
         compactProof: false,
@@ -123,7 +124,7 @@ describe('validate regular DIDs', () => {
     it('rejects create operation without a capabilityInvocation', async () => {
       const {did, mockDoc, capabilityInvocationKey} = await _generateDid();
       const mockOperation = clone(mockData.operations.create);
-      const capabilityAction = 'create';
+      const capabilityAction = 'write';
 
       // delete all methods
       delete mockDoc.authentication;
@@ -131,8 +132,8 @@ describe('validate regular DIDs', () => {
       delete mockDoc.capabilityInvocation;
 
       mockOperation.record = mockDoc;
-      // FIXME: add an AuthorizeRequest proof that will pass json-schema
-      // validation for testnet v2 *not* a valid signature
+      // FIXME: add a write proof for the accelerator that will pass
+      // json-schema validation for testnet v2 *not* a valid signature
       mockOperation.proof = clone(mockData.proof);
       const s = await jsigs.sign(mockOperation, {
         compactProof: false,
@@ -159,10 +160,10 @@ describe('validate regular DIDs', () => {
     it('rejects an improper CreateWebLedgerRecord operation', async () => {
       const {did, mockDoc, capabilityInvocationKey} = await _generateBadDid();
       const mockOperation = clone(mockData.operations.create);
-      const capabilityAction = 'create';
+      const capabilityAction = 'write';
       mockOperation.record = mockDoc;
-      // add an AuthorizeRequest proof that will pass json-schema validation for
-      // testnet v2 *not* a valid signature
+      // FIXME: add a write proof for the accelerator that will pass
+      // json-schema validation for testnet v2 *not* a valid signature
       mockOperation.proof = clone(mockData.proof);
       const s = await jsigs.sign(mockOperation, {
         compactProof: false,
@@ -189,14 +190,14 @@ describe('validate regular DIDs', () => {
     it('rejects a duplicate create operation', async () => {
       const {did, mockDoc, capabilityInvocationKey} = await _generateDid();
       const mockOperation = clone(mockData.operations.create);
-      const capabilityAction = 'create';
+      const capabilityAction = 'write';
       // add the new document to the mock document loader as if it were on
       // ledger must clone this going into the document loader, otherwise it
       // will be mutated
       mockData.existingDids[did] = clone(mockDoc);
       mockOperation.record = mockDoc;
-      // add an AuthorizeRequest proof that will pass json-schema validation for
-      // testnet v2 *not* a valid signature
+      // FIXME: add a write proof for the accelerator that will pass
+      // json-schema validation for testnet v2 *not* a valid signature
       mockOperation.proof = clone(mockData.proof);
       const s = await jsigs.sign(mockOperation, {
         compactProof: false,
@@ -211,6 +212,7 @@ describe('validate regular DIDs', () => {
         validatorConfig: mockData.ledgerConfigurations.alpha
           .operationValidator[0],
       });
+
       should.exist(result);
       result.valid.should.be.a('boolean');
       result.valid.should.be.false;
@@ -245,9 +247,9 @@ describe('validate regular DIDs', () => {
         const capabilityInvocationKey =
           mockDoc.methodFor({purpose: 'capabilityInvocation'});
         const mockOperation = clone(mockData.operations.create);
-        const capabilityAction = 'create';
+        const capabilityAction = 'write';
         mockOperation.record = mockDoc.didDocument;
-        // add an AuthorizeRequest proof that will pass json-schema
+        // add a write proof for the accelerator that will pass json-schema
         // validation for
         // testnet v2 *not* a valid signature
         mockOperation.proof = clone(mockData.proof);
@@ -281,11 +283,10 @@ describe('validate regular DIDs', () => {
         const capabilityInvocationKey =
           mockDoc.methodFor({purpose: 'capabilityInvocation'});
         const mockOperation = clone(mockData.operations.create);
-        const capabilityAction = 'create';
+        const capabilityAction = 'write';
         mockOperation.record = mockDoc.didDocument;
-        // add an AuthorizeRequest proof that will pass json-schema
-        // validation for
-        // testnet v2 *not* a valid signature
+        // add a write proof for the accelerator that will pass json-schema
+        // validation for testnet v2 *not* a valid signature
         mockOperation.proof = clone(mockData.proof);
         const s = await jsigs.sign(mockOperation, {
           compactProof: false,
@@ -331,11 +332,10 @@ describe('validate regular DIDs', () => {
         const capabilityInvocationKey =
           mockDoc.methodFor({purpose: 'capabilityInvocation'});
         const mockOperation = clone(mockData.operations.create);
-        const capabilityAction = 'create';
+        const capabilityAction = 'write';
         mockOperation.record = mockDoc.didDocument;
-        // add an AuthorizeRequest proof that will pass json-schema
-        // validation for
-        // testnet v2 *not* a valid signature
+        // add a write proof for the accelerator that will pass json-schema
+        // validation for testnet v2 *not* a valid signature
         mockOperation.proof = clone(mockData.proof);
         const s = await jsigs.sign(mockOperation, {
           compactProof: false,
@@ -367,11 +367,10 @@ describe('validate regular DIDs', () => {
         const capabilityInvocationKey =
           mockDoc.methodFor({purpose: 'capabilityInvocation'});
         const mockOperation = clone(mockData.operations.create);
-        const capabilityAction = 'create';
+        const capabilityAction = 'write';
         mockOperation.record = mockDoc.didDocument;
-        // add an AuthorizeRequest proof that will pass json-schema
-        // validation for
-        // testnet v2 *not* a valid signature
+        // add a write proof for the accelerator that will pass json-schema
+        // validation for testnet v2 *not* a valid signature
         mockOperation.proof = clone(mockData.proof);
         const s = await jsigs.sign(mockOperation, {
           compactProof: false,
@@ -407,11 +406,10 @@ describe('validate regular DIDs', () => {
         const capabilityInvocationKey =
           mockDoc.methodFor({purpose: 'capabilityInvocation'});
         const mockOperation = clone(mockData.operations.create);
-        const capabilityAction = 'create';
+        const capabilityAction = 'write';
         mockOperation.record = mockDoc.didDocument;
-        // add an AuthorizeRequest proof that will pass json-schema
-        // validation for
-        // testnet v2 *not* a valid signature
+        // add a write proof for the accelerator that will pass json-schema
+        // validation for testnet v2 *not* a valid signature
         mockOperation.proof = clone(mockData.proof);
         const s = await jsigs.sign(mockOperation, {
           compactProof: false,
@@ -454,11 +452,10 @@ describe('validate regular DIDs', () => {
         const capabilityInvocationKey =
           mockDoc.methodFor({purpose: 'capabilityInvocation'});
         const mockOperation = clone(mockData.operations.create);
-        const capabilityAction = 'create';
+        const capabilityAction = 'write';
         mockOperation.record = mockDoc.didDocument;
-        // add an AuthorizeRequest proof that will pass json-schema
-        // validation for
-        // testnet v2 *not* a valid signature
+        // add a write proof for the accelerator that will pass json-schema
+        // validation for testnet v2 *not* a valid signature
         mockOperation.proof = clone(mockData.proof);
         const s = await jsigs.sign(mockOperation, {
           compactProof: false,
@@ -495,11 +492,10 @@ describe('validate regular DIDs', () => {
         const capabilityInvocationKey =
           mockDoc.methodFor({purpose: 'capabilityInvocation'});
         const mockOperation = clone(mockData.operations.create);
-        const capabilityAction = 'create';
+        const capabilityAction = 'write';
         mockOperation.record = mockDoc.didDocument;
-        // add an AuthorizeRequest proof that will pass json-schema
-        // validation for
-        // testnet v2 *not* a valid signature
+        // add a write proof for the accelerator that will pass json-schema
+        // validation for testnet v2 *not* a valid signature
         mockOperation.proof = clone(mockData.proof);
         const s = await jsigs.sign(mockOperation, {
           compactProof: false,
@@ -534,7 +530,7 @@ describe('validate regular DIDs', () => {
     it('validates an update operation', async () => {
       const {did, mockDoc, capabilityInvocationKey} = await _generateDid();
       const mockOperation = clone(mockData.operations.update);
-      let capabilityAction = 'create';
+      let capabilityAction = 'write';
       // add the new document to the mock document loader as if it were on
       // ledger
       // clone here so we can proceed with making changes to mockDoc
@@ -553,10 +549,10 @@ describe('validate regular DIDs', () => {
       });
       mockOperation.recordPatch.patch = jsonpatch.generate(observer);
       mockOperation.recordPatch.target = did;
-      // add an AuthorizeRequest proof that will pass json-schema validation for
-      // testnet v2 *not* a valid signature
+      // FIXME: add a write proof for the accelerator that will pass
+      // json-schema validation for testnet v2 *not* a valid signature
       mockOperation.proof = clone(mockData.proof);
-      capabilityAction = 'update';
+      capabilityAction = 'write';
       const s = await jsigs.sign(mockOperation, {
         compactProof: false,
         documentLoader,
@@ -579,7 +575,7 @@ describe('validate regular DIDs', () => {
     it('rejects an update that changes the document ID', async () => {
       const {did, mockDoc, capabilityInvocationKey} = await _generateDid();
       const mockOperation = clone(mockData.operations.update);
-      let capabilityAction = 'create';
+      let capabilityAction = 'write';
       // add the new document to the mock document loader as if it were on
       // ledger
       // clone here so we can proceed with making changes to mockDoc
@@ -602,10 +598,10 @@ describe('validate regular DIDs', () => {
       });
       mockOperation.recordPatch.patch = jsonpatch.generate(observer);
       mockOperation.recordPatch.target = did;
-      // add an AuthorizeRequest proof that will pass json-schema validation for
-      // testnet v2 *not* a valid signature
+      // FIXME: add a write proof for the accelerator that will pass
+      // json-schema validation for testnet v2 *not* a valid signature
       mockOperation.proof = clone(mockData.proof);
-      capabilityAction = 'update';
+      capabilityAction = 'write';
       const s = await jsigs.sign(mockOperation, {
         compactProof: false,
         documentLoader,
@@ -679,7 +675,7 @@ describe('validate regular DIDs', () => {
     it('rejects an update with an invalid sequence', async () => {
       const {did, mockDoc, capabilityInvocationKey} = await _generateDid();
       const mockOperation = clone(mockData.operations.update);
-      let capabilityAction = 'create';
+      let capabilityAction = 'write';
       // add the new document to the mock document loader as if it were on
       // ledger
       // clone here so we can proceed with making changes to mockDoc
@@ -699,10 +695,10 @@ describe('validate regular DIDs', () => {
       });
       mockOperation.recordPatch.patch = jsonpatch.generate(observer);
       mockOperation.recordPatch.target = did;
-      // add an AuthorizeRequest proof that will pass json-schema validation for
-      // testnet v2 *not* a valid signature
+      // FIXME: add a write proof for the accelerator that will pass
+      // json-schema validation for testnet v2 *not* a valid signature
       mockOperation.proof = clone(mockData.proof);
-      capabilityAction = 'update';
+      capabilityAction = 'write';
       // specify an invalid sequence
       mockOperation.recordPatch.sequence = 10;
 
@@ -729,7 +725,7 @@ describe('validate regular DIDs', () => {
     it('rejects an update with an invalid patch', async () => {
       const {did, mockDoc, capabilityInvocationKey} = await _generateDid();
       const mockOperation = clone(mockData.operations.update);
-      let capabilityAction = 'create';
+      let capabilityAction = 'write';
       // add the new document to the mock document loader as if it were on
       // ledger
       // clone here so we can proceed with making changes to mockDoc
@@ -749,10 +745,10 @@ describe('validate regular DIDs', () => {
       });
       mockOperation.recordPatch.patch = jsonpatch.generate(observer);
       mockOperation.recordPatch.target = did;
-      // add an AuthorizeRequest proof that will pass json-schema validation for
-      // testnet v2 *not* a valid signature
+      // FIXME: add a write proof for the accelerator that will pass
+      // json-schema validation for testnet v2 *not* a valid signature
       mockOperation.proof = clone(mockData.proof);
-      capabilityAction = 'update';
+      capabilityAction = 'write';
 
       // specifiy an invalid path to create an invalid JSON patch
       mockOperation.recordPatch.patch[0].path = '/authentication/2';
@@ -781,7 +777,7 @@ describe('validate regular DIDs', () => {
     it('rejects an altered operation', async () => {
       const {did, mockDoc, capabilityInvocationKey} = await _generateDid();
       const mockOperation = clone(mockData.operations.update);
-      let capabilityAction = 'create';
+      let capabilityAction = 'write';
       // add the new document to the mock document loader as if it were on
       // ledger
       // clone here so we can proceed with making changes to mockDoc
@@ -800,21 +796,21 @@ describe('validate regular DIDs', () => {
       });
       mockOperation.recordPatch.patch = jsonpatch.generate(observer);
       mockOperation.recordPatch.target = did;
-      // add an AuthorizeRequest proof that will pass json-schema validation for
-      // testnet v2 *not* a valid signature
+      // FIXME: add a write proof for the accelerator that will pass
+      // json-schema validation for testnet v2 *not* a valid signature
       mockOperation.proof = clone(mockData.proof);
-      capabilityAction = 'update';
+      capabilityAction = 'write';
       const s = await jsigs.sign(mockOperation, {
         compactProof: false,
         documentLoader,
         suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
         purpose: new CapabilityInvocation({capability: did, capabilityAction})
       });
-
+      // remove that proof before validating
+      s.proof = [s.proof[1]];
       // after proof, change the patch target
       const {did: did2} = await _generateDid();
       mockOperation.recordPatch.target = did2;
-
       const result = await voValidator.validate({
         basisBlockHeight: 10,
         ledgerNode: mockData.ledgerNode,
@@ -841,7 +837,7 @@ describe('validate regular DIDs', () => {
 
       const {did, mockDoc} = await _generateDid();
       const mockOperation = clone(mockData.operations.update);
-      let capabilityAction = 'create';
+      let capabilityAction = 'write';
       // add the new document to the mock document loader as if it were on
       // ledger
       // clone here so we can proceed with making changes to mockDoc
@@ -862,10 +858,10 @@ describe('validate regular DIDs', () => {
 
       mockOperation.recordPatch.target = did;
 
-      // add an AuthorizeRequest proof that will pass json-schema validation for
-      // testnet v2 *not* a valid signature
+      // FIXME: add a write proof for the accelerator that will pass
+      // json-schema validation for testnet v2 *not* a valid signature
       mockOperation.proof = clone(mockData.proof);
-      capabilityAction = 'update';
+      capabilityAction = 'write';
 
       // signing with a key from another valid DID
       const s = await jsigs.sign(mockOperation, {
@@ -874,6 +870,8 @@ describe('validate regular DIDs', () => {
         suite: new Ed25519Signature2020({key: capabilityInvocationKey1}),
         purpose: new CapabilityInvocation({capability: did, capabilityAction})
       });
+      // remove that proof before validating
+      s.proof = [s.proof[1]];
       const result = await voValidator.validate({
         basisBlockHeight: 10,
         ledgerNode: mockData.ledgerNode,
@@ -897,7 +895,7 @@ describe('validate regular DIDs', () => {
 
       const {did, mockDoc, capabilityInvocationKey} = await _generateDid();
       const mockOperation = clone(mockData.operations.update);
-      let capabilityAction = 'create';
+      let capabilityAction = 'write';
       // add the new document to the mock document loader as if it were on
       // ledger
       // clone here so we can proceed with making changes to mockDoc
@@ -920,10 +918,10 @@ describe('validate regular DIDs', () => {
       // the operation is being submitted by `did` against `did1`
       mockOperation.recordPatch.target = did1;
 
-      // add an AuthorizeRequest proof that will pass json-schema validation for
-      // testnet v2 *not* a valid signature
+      // FIXME: add a write proof for the accelerator that will pass
+      // json-schema validation for testnet v2 *not* a valid signature
       mockOperation.proof = clone(mockData.proof);
-      capabilityAction = 'update';
+      capabilityAction = 'write';
 
       // signing with a key from another valid DID
       const s = await jsigs.sign(mockOperation, {
@@ -932,6 +930,8 @@ describe('validate regular DIDs', () => {
         suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
         purpose: new CapabilityInvocation({capability: did, capabilityAction})
       });
+      // remove that proof before validating
+      s.proof = [s.proof[1]];
       const result = await voValidator.validate({
         basisBlockHeight: 10,
         ledgerNode: mockData.ledgerNode,
@@ -947,11 +947,11 @@ describe('validate regular DIDs', () => {
       proofVerifyResult.error.errors[0].message.should.contain(
         'does not match root capability target');
     });
-    // proof has `capabilityAction` === `create`
+    // proof has `capabilityAction` === `write`
     it('rejects update operation without proper capabilityAction', async () => {
       const {did, mockDoc, capabilityInvocationKey} = await _generateDid();
       const mockOperation = clone(mockData.operations.update);
-      let capabilityAction = 'create';
+      let capabilityAction = 'write';
       // add the new document to the mock document loader as if it were on
       // ledger
       // clone here so we can proceed with making changes to mockDoc
@@ -969,12 +969,12 @@ describe('validate regular DIDs', () => {
       });
       mockOperation.recordPatch.patch = jsonpatch.generate(observer);
       mockOperation.recordPatch.target = did;
-      // add an AuthorizeRequest proof that will pass json-schema validation for
-      // testnet v2 *not* a valid signature
+      // FIXME: add a write proof for the accelerator that will pass
+      // json-schema validation for testnet v2 *not* a valid signature
       mockOperation.proof = clone(mockData.proof);
 
-      // capability action must be `update`
-      capabilityAction = 'create';
+      // update operations require `write` so it should reject `read`
+      capabilityAction = 'read';
 
       const s = await jsigs.sign(mockOperation, {
         compactProof: false,
@@ -999,7 +999,7 @@ describe('validate regular DIDs', () => {
     it('rejects operation when improper key used in proof 1', async () => {
       const {did, mockDoc} = await _generateDid();
       const mockOperation = clone(mockData.operations.update);
-      let capabilityAction = 'create';
+      let capabilityAction = 'write';
       // add the new document to the mock document loader as if it were on
       // ledger
       // clone here so we can proceed with making changes to mockDoc
@@ -1017,10 +1017,10 @@ describe('validate regular DIDs', () => {
       });
       mockOperation.recordPatch.patch = jsonpatch.generate(observer);
       mockOperation.recordPatch.target = did;
-      // add an AuthorizeRequest proof that will pass json-schema validation for
-      // testnet v2 *not* a valid signature
+      // FIXME: add a write proof for the accelerator that will pass
+      // json-schema validation for testnet v2 *not* a valid signature
       mockOperation.proof = clone(mockData.proof);
-      capabilityAction = 'update';
+      capabilityAction = 'write';
 
       // *must* use `capabilityInvocationKey`
       const s = await jsigs.sign(mockOperation, {
@@ -1029,6 +1029,8 @@ describe('validate regular DIDs', () => {
         suite: new Ed25519Signature2020({key: newKey}),
         purpose: new CapabilityInvocation({capability: did, capabilityAction})
       });
+      // remove that proof before validating
+      s.proof = [s.proof[1]];
       const result = await voValidator.validate({
         basisBlockHeight: 10,
         ledgerNode: mockData.ledgerNode,
@@ -1049,7 +1051,7 @@ describe('validate regular DIDs', () => {
     it('rejects operation when improper key used in proof 2', async () => {
       const {did, mockDoc, capabilityInvocationKey} = await _generateDid();
       const mockOperation = clone(mockData.operations.update);
-      let capabilityAction = 'create';
+      let capabilityAction = 'write';
       // add the new document to the mock document loader as if it were on
       // ledger
       // clone here so we can proceed with making changes to mockDoc
@@ -1070,10 +1072,10 @@ describe('validate regular DIDs', () => {
       });
       mockOperation.recordPatch.patch = jsonpatch.generate(observer);
       mockOperation.recordPatch.target = did;
-      // add an AuthorizeRequest proof that will pass json-schema validation for
-      // testnet v2 *not* a valid signature
+      // FIXME: add a write proof for the accelerator that will pass
+      // json-schema validation for testnet v2 *not* a valid signature
       mockOperation.proof = clone(mockData.proof);
-      capabilityAction = 'update';
+      capabilityAction = 'write';
 
       // *must* use `capabilityInvocationKey`
       const s = await jsigs.sign(mockOperation, {
@@ -1082,6 +1084,8 @@ describe('validate regular DIDs', () => {
         suite: new Ed25519Signature2020({key: newKey}),
         purpose: new CapabilityInvocation({capability: did, capabilityAction})
       });
+      // remove that proof before validating
+      s.proof = [s.proof[1]];
       const result = await voValidator.validate({
         basisBlockHeight: 10,
         ledgerNode: mockData.ledgerNode,
@@ -1105,7 +1109,7 @@ describe('validate regular DIDs', () => {
       const did = didDocument.id;
       const updater = new VeresOneDidDoc({didDocument});
       const mockOperation = clone(mockData.operations.update);
-      let capabilityAction = 'create';
+      let capabilityAction = 'write';
       // add the new document to the mock document loader as if it were on
       // ledger
       // clone here so we can proceed with making changes to mockDoc
@@ -1119,11 +1123,12 @@ describe('validate regular DIDs', () => {
       const capabilityInvocationKey =
         mockDoc.methodFor({purpose: 'capabilityInvocation'});
 
-      // add an AuthorizeRequest proof that will pass json-schema
-      // validation for
-      // testnet v2 *not* a valid signature
+      const keyId = mockDoc.getVerificationMethod(
+        {proofPurpose: 'capabilityInvocation'}).id;
+      // add a write proof for the ledger that will pass json-schema
+      // validation for testnet v2 *not* a valid signature
       mockOperation.proof = clone(mockData.proof);
-      capabilityAction = 'update';
+      capabilityAction = 'write';
       const s = await jsigs.sign(mockOperation, {
         compactProof: false,
         documentLoader,
@@ -1154,7 +1159,7 @@ describe('validate regular DIDs', () => {
       const did = didDocument.id;
       const updater = new VeresOneDidDoc({didDocument});
       const mockOperation = clone(mockData.operations.update);
-      let capabilityAction = 'create';
+      let capabilityAction = 'write';
       // add the new document to the mock document loader as if it were on
       // ledger
       // clone here so we can proceed with making changes to mockDoc
@@ -1170,11 +1175,12 @@ describe('validate regular DIDs', () => {
 
       const capabilityInvocationKey =
         mockDoc.methodFor({purpose: 'capabilityInvocation'});
-      // add an AuthorizeRequest proof that will pass json-schema
-      // validation for
-      // testnet v2 *not* a valid signature
+      const keyId = mockDoc.getVerificationMethod(
+        {proofPurpose: 'capabilityInvocation'}).id;
+      // add a write proof that will pass json-schema
+      // validation for testnet v2 *not* a valid signature
       mockOperation.proof = clone(mockData.proof);
-      capabilityAction = 'update';
+      capabilityAction = 'write';
       const s = await jsigs.sign(mockOperation, {
         compactProof: false,
         documentLoader,
@@ -1217,7 +1223,7 @@ describe('validate regular DIDs', () => {
         const did = didDocument.id;
         const updater = new VeresOneDidDoc({didDocument});
         const mockOperation = clone(mockData.operations.update);
-        let capabilityAction = 'create';
+        let capabilityAction = 'write';
         mockData.existingDids[did] = clone(didDocument);
 
         updater.observe();
@@ -1234,11 +1240,11 @@ describe('validate regular DIDs', () => {
         const capabilityInvocationKey =
           mockDoc.methodFor({purpose: 'capabilityInvocation'});
 
-        // add an AuthorizeRequest proof that will pass json-schema
+        // add a write proof for the accelerator that will pass json-schema
         // validation for
         // testnet v2 *not* a valid signature
         mockOperation.proof = clone(mockData.proof);
-        capabilityAction = 'update';
+        capabilityAction = 'write';
         const s = await jsigs.sign(mockOperation, {
           compactProof: false,
           documentLoader,
@@ -1262,7 +1268,7 @@ describe('validate regular DIDs', () => {
         const did = didDocument.id;
         const updater = new VeresOneDidDoc({didDocument});
         const mockOperation = clone(mockData.operations.update);
-        let capabilityAction = 'create';
+        let capabilityAction = 'write';
         mockData.existingDids[did] = clone(didDocument);
 
         updater.observe();
@@ -1285,11 +1291,11 @@ describe('validate regular DIDs', () => {
         const capabilityInvocationKey =
           mockDoc.methodFor({purpose: 'capabilityInvocation'});
 
-        // add an AuthorizeRequest proof that will pass json-schema
+        // add a write proof for the accelerator that will pass json-schema
         // validation for
         // testnet v2 *not* a valid signature
         mockOperation.proof = clone(mockData.proof);
-        capabilityAction = 'update';
+        capabilityAction = 'write';
         const s = await jsigs.sign(mockOperation, {
           compactProof: false,
           documentLoader,
@@ -1313,7 +1319,7 @@ describe('validate regular DIDs', () => {
         const did = didDocument.id;
         const updater = new VeresOneDidDoc({didDocument});
         const mockOperation = clone(mockData.operations.update);
-        let capabilityAction = 'create';
+        let capabilityAction = 'write';
         mockData.existingDids[did] = clone(didDocument);
 
         updater.observe();
@@ -1330,11 +1336,11 @@ describe('validate regular DIDs', () => {
         const capabilityInvocationKey =
           mockDoc.methodFor({purpose: 'capabilityInvocation'});
 
-        // add an AuthorizeRequest proof that will pass json-schema
+        // add a write proof for the accelerator that will pass json-schema
         // validation for
         // testnet v2 *not* a valid signature
         mockOperation.proof = clone(mockData.proof);
-        capabilityAction = 'update';
+        capabilityAction = 'write';
         const s = await jsigs.sign(mockOperation, {
           compactProof: false,
           documentLoader,
@@ -1361,7 +1367,7 @@ describe('validate regular DIDs', () => {
         const did = didDocument.id;
         const updater = new VeresOneDidDoc({didDocument});
         const mockOperation = clone(mockData.operations.update);
-        let capabilityAction = 'create';
+        let capabilityAction = 'write';
         mockData.existingDids[did] = clone(didDocument);
 
         updater.observe();
@@ -1378,11 +1384,11 @@ describe('validate regular DIDs', () => {
         const capabilityInvocationKey =
           mockDoc.methodFor({purpose: 'capabilityInvocation'});
 
-        // add an AuthorizeRequest proof that will pass json-schema
+        // add a write proof for the accelerator that will pass json-schema
         // validation for
         // testnet v2 *not* a valid signature
         mockOperation.proof = clone(mockData.proof);
-        capabilityAction = 'update';
+        capabilityAction = 'write';
         const s = await jsigs.sign(mockOperation, {
           compactProof: false,
           documentLoader,
@@ -1409,7 +1415,7 @@ describe('validate regular DIDs', () => {
         const did = didDocument.id;
         const updater = new VeresOneDidDoc({didDocument});
         const mockOperation = clone(mockData.operations.update);
-        let capabilityAction = 'create';
+        let capabilityAction = 'write';
         mockData.existingDids[did] = clone(didDocument);
 
         updater.observe();
@@ -1432,11 +1438,11 @@ describe('validate regular DIDs', () => {
         const capabilityInvocationKey =
           mockDoc.methodFor({purpose: 'capabilityInvocation'});
 
-        // add an AuthorizeRequest proof that will pass json-schema
+        // add a write proof for the accelerator that will pass json-schema
         // validation for
         // testnet v2 *not* a valid signature
         mockOperation.proof = clone(mockData.proof);
-        capabilityAction = 'update';
+        capabilityAction = 'write';
         const s = await jsigs.sign(mockOperation, {
           compactProof: false,
           documentLoader,

--- a/test/mocha/05-validate-async.js
+++ b/test/mocha/05-validate-async.js
@@ -44,7 +44,6 @@ describe('validate regular DIDs', () => {
       // FIXME: add a write proof for the ledger that will pass
       // json-schema validation for testnet v2 *not* a valid signature
       mockOperation.proof = clone(mockData.proof);
-      mockOperation.proof.invocationTarget = mockOperation.record.id;
       const s = await jsigs.sign(mockOperation, {
         documentLoader,
         suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
@@ -73,7 +72,7 @@ describe('validate regular DIDs', () => {
       // FIXME: add a write proof for the accelerator that will pass
       // json-schema validation for testnet v2 *not* a valid signature
       mockOperation.proof = clone(mockData.proof);
-      mockOperation.proof.invocationTarget = mockOperation.record.id;
+
       const s = await jsigs.sign(mockOperation, {
         documentLoader,
         suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
@@ -111,7 +110,7 @@ describe('validate regular DIDs', () => {
       // FIXME: add a write proof for the accelerator that will pass
       // json-schema validation for testnet v2 *not* a valid signature
       mockOperation.proof = clone(mockData.proof);
-      mockOperation.proof.invocationTarget = mockOperation.record.id;
+
       const s = await jsigs.sign(mockOperation, {
         documentLoader,
         suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
@@ -146,7 +145,7 @@ describe('validate regular DIDs', () => {
       // FIXME: add a write proof for the accelerator that will pass
       // json-schema validation for testnet v2 *not* a valid signature
       mockOperation.proof = clone(mockData.proof);
-      mockOperation.proof.invocationTarget = mockOperation.record.id;
+
       const s = await jsigs.sign(mockOperation, {
         documentLoader,
         suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
@@ -180,7 +179,7 @@ describe('validate regular DIDs', () => {
       // FIXME: add a write proof for the accelerator that will pass
       // json-schema validation for testnet v2 *not* a valid signature
       mockOperation.proof = clone(mockData.proof);
-      mockOperation.proof.invocationTarget = mockOperation.record.id;
+
       const s = await jsigs.sign(mockOperation, {
         documentLoader,
         suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
@@ -218,7 +217,7 @@ describe('validate regular DIDs', () => {
       // FIXME: add a write proof for the accelerator that will pass
       // json-schema validation for testnet v2 *not* a valid signature
       mockOperation.proof = clone(mockData.proof);
-      mockOperation.proof.invocationTarget = mockOperation.record.id;
+
       const s = await jsigs.sign(mockOperation, {
         documentLoader,
         suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
@@ -276,7 +275,7 @@ describe('validate regular DIDs', () => {
         // validation for
         // testnet v2 *not* a valid signature
         mockOperation.proof = clone(mockData.proof);
-        mockOperation.proof.invocationTarget = mockOperation.record.id;
+
         const s = await jsigs.sign(mockOperation, {
           documentLoader,
           suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
@@ -315,7 +314,7 @@ describe('validate regular DIDs', () => {
         // add a write proof for the accelerator that will pass json-schema
         // validation for testnet v2 *not* a valid signature
         mockOperation.proof = clone(mockData.proof);
-        mockOperation.proof.invocationTarget = mockOperation.record.id;
+
         const s = await jsigs.sign(mockOperation, {
           documentLoader,
           suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
@@ -368,7 +367,7 @@ describe('validate regular DIDs', () => {
         // add a write proof for the accelerator that will pass json-schema
         // validation for testnet v2 *not* a valid signature
         mockOperation.proof = clone(mockData.proof);
-        mockOperation.proof.invocationTarget = mockOperation.record.id;
+
         const s = await jsigs.sign(mockOperation, {
           documentLoader,
           suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
@@ -407,7 +406,7 @@ describe('validate regular DIDs', () => {
         // add a write proof for the accelerator that will pass json-schema
         // validation for testnet v2 *not* a valid signature
         mockOperation.proof = clone(mockData.proof);
-        mockOperation.proof.invocationTarget = mockOperation.record.id;
+
         const s = await jsigs.sign(mockOperation, {
           documentLoader,
           suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
@@ -450,7 +449,7 @@ describe('validate regular DIDs', () => {
         // add a write proof for the accelerator that will pass json-schema
         // validation for testnet v2 *not* a valid signature
         mockOperation.proof = clone(mockData.proof);
-        mockOperation.proof.invocationTarget = mockOperation.record.id;
+
         const s = await jsigs.sign(mockOperation, {
           documentLoader,
           suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
@@ -500,7 +499,7 @@ describe('validate regular DIDs', () => {
         // add a write proof for the accelerator that will pass json-schema
         // validation for testnet v2 *not* a valid signature
         mockOperation.proof = clone(mockData.proof);
-        mockOperation.proof.invocationTarget = mockOperation.record.id;
+
         const s = await jsigs.sign(mockOperation, {
           documentLoader,
           suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
@@ -544,7 +543,6 @@ describe('validate regular DIDs', () => {
         // add a write proof for the accelerator that will pass json-schema
         // validation for testnet v2 *not* a valid signature
         mockOperation.proof = clone(mockData.proof);
-        mockOperation.proof.invocationTarget = mockOperation.record.id;
         const s = await jsigs.sign(mockOperation, {
           documentLoader,
           suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
@@ -603,7 +601,7 @@ describe('validate regular DIDs', () => {
       // FIXME: add a write proof for the accelerator that will pass
       // json-schema validation for testnet v2 *not* a valid signature
       mockOperation.proof = clone(mockData.proof);
-      mockOperation.proof.invocationTarget = did;
+
       const s = await jsigs.sign(mockOperation, {
         documentLoader,
         suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
@@ -655,7 +653,7 @@ describe('validate regular DIDs', () => {
       // FIXME: add a write proof for the accelerator that will pass
       // json-schema validation for testnet v2 *not* a valid signature
       mockOperation.proof = clone(mockData.proof);
-      mockOperation.proof.invocationTarget = did;
+
       const s = await jsigs.sign(mockOperation, {
         documentLoader,
         suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
@@ -703,7 +701,7 @@ describe('validate regular DIDs', () => {
       // add a write proof for the ledger that will pass json-schema
       // validation for testnet v2 *not* a valid signature
       mockOperation.proof = clone(mockData.proof);
-      mockOperation.proof.invocationTarget = did;
+
       const s = await jsigs.sign(mockOperation, {
         documentLoader,
         suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
@@ -760,7 +758,7 @@ describe('validate regular DIDs', () => {
       // FIXME: add a write proof for the accelerator that will pass
       // json-schema validation for testnet v2 *not* a valid signature
       mockOperation.proof = clone(mockData.proof);
-      mockOperation.proof.invocationTarget = did;
+
       const s = await jsigs.sign(mockOperation, {
         documentLoader,
         suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
@@ -812,7 +810,7 @@ describe('validate regular DIDs', () => {
       mockOperation.proof = clone(mockData.proof);
       // specifiy an invalid path to create an invalid JSON patch
       mockOperation.recordPatch.patch[0].path = '/authentication/2';
-      mockOperation.proof.invocationTarget = did;
+
       const s = await jsigs.sign(mockOperation, {
         documentLoader,
         suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
@@ -928,7 +926,7 @@ describe('validate regular DIDs', () => {
       // FIXME: add a write proof for the accelerator that will pass
       // json-schema validation for testnet v2 *not* a valid signature
       mockOperation.proof = clone(mockData.proof);
-      mockOperation.proof.invocationTarget = did;
+
       const s = await jsigs.sign(mockOperation, {
         documentLoader,
         suite: new Ed25519Signature2020({key: capabilityInvocationKey1}),
@@ -1040,7 +1038,6 @@ describe('validate regular DIDs', () => {
       // update operations require `write` so it should reject `read`
       capabilityAction = 'read';
 
-      mockOperation.proof.invocationTarget = did;
       const s = await jsigs.sign(mockOperation, {
         documentLoader,
         suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
@@ -1092,7 +1089,7 @@ describe('validate regular DIDs', () => {
 
       // *must* use `capabilityInvocationKey`
       mockOperation.proof = clone(mockData.proof);
-      mockOperation.proof.invocationTarget = did;
+
       const s = await jsigs.sign(mockOperation, {
         documentLoader,
         suite: new Ed25519Signature2020({key: newKey}),
@@ -1149,7 +1146,7 @@ describe('validate regular DIDs', () => {
 
       // *must* use `capabilityInvocationKey`
       mockOperation.proof = clone(mockData.proof);
-      mockOperation.proof.invocationTarget = did;
+
       const s = await jsigs.sign(mockOperation, {
         documentLoader,
         suite: new Ed25519Signature2020({key: newKey}),
@@ -1199,7 +1196,7 @@ describe('validate regular DIDs', () => {
       // add a write proof for the ledger that will pass json-schema
       // validation for testnet v2 *not* a valid signature
       mockOperation.proof = clone(mockData.proof);
-      mockOperation.proof.invocationTarget = did;
+
       const s = await jsigs.sign(mockOperation, {
         documentLoader,
         suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
@@ -1252,7 +1249,7 @@ describe('validate regular DIDs', () => {
       // add a write proof that will pass json-schema
       // validation for testnet v2 *not* a valid signature
       mockOperation.proof = clone(mockData.proof);
-      mockOperation.proof.invocationTarget = did;
+
       const s = await jsigs.sign(mockOperation, {
         documentLoader,
         suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
@@ -1319,7 +1316,7 @@ describe('validate regular DIDs', () => {
         // validation for
         // testnet v2 *not* a valid signature
         mockOperation.proof = clone(mockData.proof);
-        mockOperation.proof.invocationTarget = did;
+
         const s = await jsigs.sign(mockOperation, {
           documentLoader,
           suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
@@ -1373,7 +1370,7 @@ describe('validate regular DIDs', () => {
         // validation for
         // testnet v2 *not* a valid signature
         mockOperation.proof = clone(mockData.proof);
-        mockOperation.proof.invocationTarget = did;
+
         const s = await jsigs.sign(mockOperation, {
           documentLoader,
           suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
@@ -1421,7 +1418,7 @@ describe('validate regular DIDs', () => {
         // validation for
         // testnet v2 *not* a valid signature
         mockOperation.proof = clone(mockData.proof);
-        mockOperation.proof.invocationTarget = did;
+
         const s = await jsigs.sign(mockOperation, {
           documentLoader,
           suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
@@ -1472,7 +1469,7 @@ describe('validate regular DIDs', () => {
         // validation for
         // testnet v2 *not* a valid signature
         mockOperation.proof = clone(mockData.proof);
-        mockOperation.proof.invocationTarget = did;
+
         const s = await jsigs.sign(mockOperation, {
           documentLoader,
           suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
@@ -1529,7 +1526,7 @@ describe('validate regular DIDs', () => {
         // validation for
         // testnet v2 *not* a valid signature
         mockOperation.proof = clone(mockData.proof);
-        mockOperation.proof.invocationTarget = did;
+
         const s = await jsigs.sign(mockOperation, {
           documentLoader,
           suite: new Ed25519Signature2020({key: capabilityInvocationKey}),

--- a/test/mocha/05-validate-async.js
+++ b/test/mocha/05-validate-async.js
@@ -45,16 +45,14 @@ describe('validate regular DIDs', () => {
       // json-schema validation for testnet v2 *not* a valid signature
       mockOperation.proof = clone(mockData.proof);
       mockOperation.proof.invocationTarget = mockOperation.record.id;
-      const purpose = new CapabilityInvocation({
-        capability: did,
-        capabilityAction,
-        // FIXME this is not making it into the signature
-        invocationTarget: mockDoc.id
-      });
       const s = await jsigs.sign(mockOperation, {
         documentLoader,
         suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
-        purpose
+        purpose: new CapabilityInvocation({
+          capability: did,
+          capabilityAction,
+          invocationTarget: mockDoc.id
+        })
       });
       const result = await voValidator.validate({
         basisBlockHeight: 0,
@@ -75,11 +73,15 @@ describe('validate regular DIDs', () => {
       // FIXME: add a write proof for the accelerator that will pass
       // json-schema validation for testnet v2 *not* a valid signature
       mockOperation.proof = clone(mockData.proof);
+      mockOperation.proof.invocationTarget = mockOperation.record.id;
       const s = await jsigs.sign(mockOperation, {
-
         documentLoader,
         suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
-        purpose: new CapabilityInvocation({capability: did, capabilityAction})
+        purpose: new CapabilityInvocation({
+          capability: did,
+          capabilityAction,
+          invocationTarget: mockDoc.id
+        })
       });
       let err;
       let result;
@@ -109,11 +111,15 @@ describe('validate regular DIDs', () => {
       // FIXME: add a write proof for the accelerator that will pass
       // json-schema validation for testnet v2 *not* a valid signature
       mockOperation.proof = clone(mockData.proof);
+      mockOperation.proof.invocationTarget = mockOperation.record.id;
       const s = await jsigs.sign(mockOperation, {
-
         documentLoader,
         suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
-        purpose: new CapabilityInvocation({capability: did, capabilityAction})
+        purpose: new CapabilityInvocation({
+          capability: did,
+          capabilityAction,
+          invocationTarget: did
+        })
       });
       const result = await voValidator.validate({
         basisBlockHeight: 0,
@@ -140,11 +146,15 @@ describe('validate regular DIDs', () => {
       // FIXME: add a write proof for the accelerator that will pass
       // json-schema validation for testnet v2 *not* a valid signature
       mockOperation.proof = clone(mockData.proof);
+      mockOperation.proof.invocationTarget = mockOperation.record.id;
       const s = await jsigs.sign(mockOperation, {
-
         documentLoader,
         suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
-        purpose: new CapabilityInvocation({capability: did, capabilityAction})
+        purpose: new CapabilityInvocation({
+          capability: did,
+          capabilityAction,
+          invocationTarget: mockDoc.id
+        })
       });
       const result = await voValidator.validate({
         basisBlockHeight: 0,
@@ -170,11 +180,15 @@ describe('validate regular DIDs', () => {
       // FIXME: add a write proof for the accelerator that will pass
       // json-schema validation for testnet v2 *not* a valid signature
       mockOperation.proof = clone(mockData.proof);
+      mockOperation.proof.invocationTarget = mockOperation.record.id;
       const s = await jsigs.sign(mockOperation, {
-
         documentLoader,
         suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
-        purpose: new CapabilityInvocation({capability: did, capabilityAction})
+        purpose: new CapabilityInvocation({
+          capability: did,
+          capabilityAction,
+          invocationTarget: mockDoc.id
+        })
       });
       const result = await voValidator.validate({
         basisBlockHeight: 0,
@@ -204,11 +218,15 @@ describe('validate regular DIDs', () => {
       // FIXME: add a write proof for the accelerator that will pass
       // json-schema validation for testnet v2 *not* a valid signature
       mockOperation.proof = clone(mockData.proof);
+      mockOperation.proof.invocationTarget = mockOperation.record.id;
       const s = await jsigs.sign(mockOperation, {
-
         documentLoader,
         suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
-        purpose: new CapabilityInvocation({capability: did, capabilityAction})
+        purpose: new CapabilityInvocation({
+          capability: did,
+          capabilityAction,
+          invocationTarget: mockDoc.id
+        })
       });
       const result = await voValidator.validate({
         basisBlockHeight: 10,
@@ -258,11 +276,15 @@ describe('validate regular DIDs', () => {
         // validation for
         // testnet v2 *not* a valid signature
         mockOperation.proof = clone(mockData.proof);
+        mockOperation.proof.invocationTarget = mockOperation.record.id;
         const s = await jsigs.sign(mockOperation, {
-
           documentLoader,
           suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
-          purpose: new CapabilityInvocation({capability: did, capabilityAction})
+          purpose: new CapabilityInvocation({
+            capability: did,
+            capabilityAction,
+            invocationTarget: mockOperation.record.id
+          })
         });
         const result = await voValidator.validate({
           basisBlockHeight: 0,
@@ -293,11 +315,15 @@ describe('validate regular DIDs', () => {
         // add a write proof for the accelerator that will pass json-schema
         // validation for testnet v2 *not* a valid signature
         mockOperation.proof = clone(mockData.proof);
+        mockOperation.proof.invocationTarget = mockOperation.record.id;
         const s = await jsigs.sign(mockOperation, {
-
           documentLoader,
           suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
-          purpose: new CapabilityInvocation({capability: did, capabilityAction})
+          purpose: new CapabilityInvocation({
+            capability: did,
+            capabilityAction,
+            invocationTarget: mockOperation.record.id
+          })
         });
         const configMissingValidatorParameterSet = clone(validatorConfig);
         // this DID triggers a TerribleValidatorParameterSetError
@@ -342,11 +368,15 @@ describe('validate regular DIDs', () => {
         // add a write proof for the accelerator that will pass json-schema
         // validation for testnet v2 *not* a valid signature
         mockOperation.proof = clone(mockData.proof);
+        mockOperation.proof.invocationTarget = mockOperation.record.id;
         const s = await jsigs.sign(mockOperation, {
-
           documentLoader,
           suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
-          purpose: new CapabilityInvocation({capability: did, capabilityAction})
+          purpose: new CapabilityInvocation({
+            capability: did,
+            capabilityAction,
+            invocationTarget: mockOperation.record.id
+          })
         });
         const result = await voValidator.validate({
           basisBlockHeight: 0,
@@ -377,11 +407,15 @@ describe('validate regular DIDs', () => {
         // add a write proof for the accelerator that will pass json-schema
         // validation for testnet v2 *not* a valid signature
         mockOperation.proof = clone(mockData.proof);
+        mockOperation.proof.invocationTarget = mockOperation.record.id;
         const s = await jsigs.sign(mockOperation, {
-
           documentLoader,
           suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
-          purpose: new CapabilityInvocation({capability: did, capabilityAction})
+          purpose: new CapabilityInvocation({
+            capability: did,
+            capabilityAction,
+            invocationTarget: mockOperation.record.id
+          })
         });
         const result = await voValidator.validate({
           basisBlockHeight: 0,
@@ -416,11 +450,15 @@ describe('validate regular DIDs', () => {
         // add a write proof for the accelerator that will pass json-schema
         // validation for testnet v2 *not* a valid signature
         mockOperation.proof = clone(mockData.proof);
+        mockOperation.proof.invocationTarget = mockOperation.record.id;
         const s = await jsigs.sign(mockOperation, {
-
           documentLoader,
           suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
-          purpose: new CapabilityInvocation({capability: did, capabilityAction})
+          purpose: new CapabilityInvocation({
+            capability: did,
+            capabilityAction,
+            invocationTarget: mockOperation.record.id
+          })
         });
         const result = await voValidator.validate({
           basisBlockHeight: 0,
@@ -462,11 +500,15 @@ describe('validate regular DIDs', () => {
         // add a write proof for the accelerator that will pass json-schema
         // validation for testnet v2 *not* a valid signature
         mockOperation.proof = clone(mockData.proof);
+        mockOperation.proof.invocationTarget = mockOperation.record.id;
         const s = await jsigs.sign(mockOperation, {
-
           documentLoader,
           suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
-          purpose: new CapabilityInvocation({capability: did, capabilityAction})
+          purpose: new CapabilityInvocation({
+            capability: did,
+            capabilityAction,
+            invocationTarget: mockOperation.record.id
+          })
         });
         const result = await voValidator.validate({
           basisBlockHeight: 0,
@@ -502,11 +544,15 @@ describe('validate regular DIDs', () => {
         // add a write proof for the accelerator that will pass json-schema
         // validation for testnet v2 *not* a valid signature
         mockOperation.proof = clone(mockData.proof);
+        mockOperation.proof.invocationTarget = mockOperation.record.id;
         const s = await jsigs.sign(mockOperation, {
-
           documentLoader,
           suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
-          purpose: new CapabilityInvocation({capability: did, capabilityAction})
+          purpose: new CapabilityInvocation({
+            capability: did,
+            capabilityAction,
+            invocationTarget: mockOperation.record.id
+          })
         });
 
         // this document does not exist on the ledger
@@ -557,11 +603,15 @@ describe('validate regular DIDs', () => {
       // FIXME: add a write proof for the accelerator that will pass
       // json-schema validation for testnet v2 *not* a valid signature
       mockOperation.proof = clone(mockData.proof);
+      mockOperation.proof.invocationTarget = did;
       const s = await jsigs.sign(mockOperation, {
-
         documentLoader,
         suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
-        purpose: new CapabilityInvocation({capability: did, capabilityAction})
+        purpose: new CapabilityInvocation({
+          capability: did,
+          capabilityAction,
+          invocationTarget: did
+        })
       });
       const result = await voValidator.validate({
         basisBlockHeight: 10,
@@ -605,11 +655,15 @@ describe('validate regular DIDs', () => {
       // FIXME: add a write proof for the accelerator that will pass
       // json-schema validation for testnet v2 *not* a valid signature
       mockOperation.proof = clone(mockData.proof);
+      mockOperation.proof.invocationTarget = did;
       const s = await jsigs.sign(mockOperation, {
-
         documentLoader,
         suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
-        purpose: new CapabilityInvocation({capability: did, capabilityAction})
+        purpose: new CapabilityInvocation({
+          capability: did,
+          capabilityAction,
+          invocationTarget: did
+        })
       });
       const result = await voValidator.validate({
         basisBlockHeight: 10,
@@ -649,11 +703,15 @@ describe('validate regular DIDs', () => {
       // add a write proof for the ledger that will pass json-schema
       // validation for testnet v2 *not* a valid signature
       mockOperation.proof = clone(mockData.proof);
+      mockOperation.proof.invocationTarget = did;
       const s = await jsigs.sign(mockOperation, {
-
         documentLoader,
         suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
-        purpose: new CapabilityInvocation({capability: did, capabilityAction})
+        purpose: new CapabilityInvocation({
+          capability: did,
+          capabilityAction,
+          invocationTarget: did
+        })
       });
       const result = await voValidator.validate({
         basisBlockHeight: 10,
@@ -697,17 +755,20 @@ describe('validate regular DIDs', () => {
       });
       mockOperation.recordPatch.patch = jsonpatch.generate(observer);
       mockOperation.recordPatch.target = did;
+      // specify an invalid sequence
+      mockOperation.recordPatch.sequence = 10;
       // FIXME: add a write proof for the accelerator that will pass
       // json-schema validation for testnet v2 *not* a valid signature
       mockOperation.proof = clone(mockData.proof);
-      // specify an invalid sequence
-      mockOperation.recordPatch.sequence = 10;
-
+      mockOperation.proof.invocationTarget = did;
       const s = await jsigs.sign(mockOperation, {
-
         documentLoader,
         suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
-        purpose: new CapabilityInvocation({capability: did, capabilityAction})
+        purpose: new CapabilityInvocation({
+          capability: did,
+          capabilityAction,
+          invocationTarget: did
+        })
       });
       const result = await voValidator.validate({
         basisBlockHeight: 10,
@@ -749,15 +810,17 @@ describe('validate regular DIDs', () => {
       // FIXME: add a write proof for the accelerator that will pass
       // json-schema validation for testnet v2 *not* a valid signature
       mockOperation.proof = clone(mockData.proof);
-
       // specifiy an invalid path to create an invalid JSON patch
       mockOperation.recordPatch.patch[0].path = '/authentication/2';
-
+      mockOperation.proof.invocationTarget = did;
       const s = await jsigs.sign(mockOperation, {
-
         documentLoader,
         suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
-        purpose: new CapabilityInvocation({capability: did, capabilityAction})
+        purpose: new CapabilityInvocation({
+          capability: did,
+          capabilityAction,
+          invocationTarget: did
+        })
       });
       const result = await voValidator.validate({
         basisBlockHeight: 10,
@@ -799,11 +862,15 @@ describe('validate regular DIDs', () => {
       // FIXME: add a write proof for the accelerator that will pass
       // json-schema validation for testnet v2 *not* a valid signature
       mockOperation.proof = clone(mockData.proof);
+      mockOperation.proof.invocationTarget = did;
       const s = await jsigs.sign(mockOperation, {
-
         documentLoader,
         suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
-        purpose: new CapabilityInvocation({capability: did, capabilityAction})
+        purpose: new CapabilityInvocation({
+          capability: did,
+          capabilityAction,
+          invocationTarget: did
+        })
       });
       // after proof, change the patch target
       const {did: did2} = await _generateDid();
@@ -858,13 +925,15 @@ describe('validate regular DIDs', () => {
       // FIXME: add a write proof for the accelerator that will pass
       // json-schema validation for testnet v2 *not* a valid signature
       mockOperation.proof = clone(mockData.proof);
-
-      // signing with a key from another valid DID
+      mockOperation.proof.invocationTarget = did;
       const s = await jsigs.sign(mockOperation, {
-
         documentLoader,
         suite: new Ed25519Signature2020({key: capabilityInvocationKey1}),
-        purpose: new CapabilityInvocation({capability: did, capabilityAction})
+        purpose: new CapabilityInvocation({
+          capability: did,
+          capabilityAction,
+          invocationTarget: did
+        })
       });
       const result = await voValidator.validate({
         basisBlockHeight: 10,
@@ -915,13 +984,15 @@ describe('validate regular DIDs', () => {
       // FIXME: add a write proof for the accelerator that will pass
       // json-schema validation for testnet v2 *not* a valid signature
       mockOperation.proof = clone(mockData.proof);
-
-      // signing with a key from another valid DID
+      mockOperation.proof.invocationTarget = did;
       const s = await jsigs.sign(mockOperation, {
-
         documentLoader,
         suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
-        purpose: new CapabilityInvocation({capability: did, capabilityAction})
+        purpose: new CapabilityInvocation({
+          capability: did,
+          capabilityAction,
+          invocationTarget: did
+        })
       });
       const result = await voValidator.validate({
         basisBlockHeight: 10,
@@ -967,11 +1038,15 @@ describe('validate regular DIDs', () => {
       // update operations require `write` so it should reject `read`
       capabilityAction = 'read';
 
+      mockOperation.proof.invocationTarget = did;
       const s = await jsigs.sign(mockOperation, {
-
         documentLoader,
         suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
-        purpose: new CapabilityInvocation({capability: did, capabilityAction})
+        purpose: new CapabilityInvocation({
+          capability: did,
+          capabilityAction,
+          invocationTarget: did
+        })
       });
       const result = await voValidator.validate({
         basisBlockHeight: 10,
@@ -1014,11 +1089,16 @@ describe('validate regular DIDs', () => {
       capabilityAction = 'write';
 
       // *must* use `capabilityInvocationKey`
+      mockOperation.proof = clone(mockData.proof);
+      mockOperation.proof.invocationTarget = did;
       const s = await jsigs.sign(mockOperation, {
-
         documentLoader,
         suite: new Ed25519Signature2020({key: newKey}),
-        purpose: new CapabilityInvocation({capability: did, capabilityAction})
+        purpose: new CapabilityInvocation({
+          capability: did,
+          capabilityAction,
+          invocationTarget: did
+        })
       });
       const result = await voValidator.validate({
         basisBlockHeight: 10,
@@ -1066,11 +1146,16 @@ describe('validate regular DIDs', () => {
       mockOperation.proof = clone(mockData.proof);
 
       // *must* use `capabilityInvocationKey`
+      mockOperation.proof = clone(mockData.proof);
+      mockOperation.proof.invocationTarget = did;
       const s = await jsigs.sign(mockOperation, {
-
         documentLoader,
         suite: new Ed25519Signature2020({key: newKey}),
-        purpose: new CapabilityInvocation({capability: did, capabilityAction})
+        purpose: new CapabilityInvocation({
+          capability: did,
+          capabilityAction,
+          invocationTarget: did
+        })
       });
       const result = await voValidator.validate({
         basisBlockHeight: 10,
@@ -1112,11 +1197,15 @@ describe('validate regular DIDs', () => {
       // add a write proof for the ledger that will pass json-schema
       // validation for testnet v2 *not* a valid signature
       mockOperation.proof = clone(mockData.proof);
+      mockOperation.proof.invocationTarget = did;
       const s = await jsigs.sign(mockOperation, {
-
         documentLoader,
         suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
-        purpose: new CapabilityInvocation({capability: did, capabilityAction})
+        purpose: new CapabilityInvocation({
+          capability: did,
+          capabilityAction,
+          invocationTarget: did
+        })
       });
       const result = await voValidator.validate({
         basisBlockHeight: 10,
@@ -1161,11 +1250,15 @@ describe('validate regular DIDs', () => {
       // add a write proof that will pass json-schema
       // validation for testnet v2 *not* a valid signature
       mockOperation.proof = clone(mockData.proof);
+      mockOperation.proof.invocationTarget = did;
       const s = await jsigs.sign(mockOperation, {
-
         documentLoader,
         suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
-        purpose: new CapabilityInvocation({capability: did, capabilityAction})
+        purpose: new CapabilityInvocation({
+          capability: did,
+          capabilityAction,
+          invocationTarget: did
+        })
       });
       const result = await voValidator.validate({
         basisBlockHeight: 10,
@@ -1224,11 +1317,15 @@ describe('validate regular DIDs', () => {
         // validation for
         // testnet v2 *not* a valid signature
         mockOperation.proof = clone(mockData.proof);
+        mockOperation.proof.invocationTarget = did;
         const s = await jsigs.sign(mockOperation, {
-
           documentLoader,
           suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
-          purpose: new CapabilityInvocation({capability: did, capabilityAction})
+          purpose: new CapabilityInvocation({
+            capability: did,
+            capabilityAction,
+            invocationTarget: did
+          })
         });
         const result = await voValidator.validate({
           basisBlockHeight: 10,
@@ -1274,11 +1371,15 @@ describe('validate regular DIDs', () => {
         // validation for
         // testnet v2 *not* a valid signature
         mockOperation.proof = clone(mockData.proof);
+        mockOperation.proof.invocationTarget = did;
         const s = await jsigs.sign(mockOperation, {
-
           documentLoader,
           suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
-          purpose: new CapabilityInvocation({capability: did, capabilityAction})
+          purpose: new CapabilityInvocation({
+            capability: did,
+            capabilityAction,
+            invocationTarget: did
+          })
         });
         const result = await voValidator.validate({
           basisBlockHeight: 10,
@@ -1318,11 +1419,15 @@ describe('validate regular DIDs', () => {
         // validation for
         // testnet v2 *not* a valid signature
         mockOperation.proof = clone(mockData.proof);
+        mockOperation.proof.invocationTarget = did;
         const s = await jsigs.sign(mockOperation, {
-
           documentLoader,
           suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
-          purpose: new CapabilityInvocation({capability: did, capabilityAction})
+          purpose: new CapabilityInvocation({
+            capability: did,
+            capabilityAction,
+            invocationTarget: did
+          })
         });
         const result = await voValidator.validate({
           basisBlockHeight: 10,
@@ -1365,11 +1470,15 @@ describe('validate regular DIDs', () => {
         // validation for
         // testnet v2 *not* a valid signature
         mockOperation.proof = clone(mockData.proof);
+        mockOperation.proof.invocationTarget = did;
         const s = await jsigs.sign(mockOperation, {
-
           documentLoader,
           suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
-          purpose: new CapabilityInvocation({capability: did, capabilityAction})
+          purpose: new CapabilityInvocation({
+            capability: did,
+            capabilityAction,
+            invocationTarget: did
+          })
         });
         const result = await voValidator.validate({
           basisBlockHeight: 10,
@@ -1418,11 +1527,15 @@ describe('validate regular DIDs', () => {
         // validation for
         // testnet v2 *not* a valid signature
         mockOperation.proof = clone(mockData.proof);
+        mockOperation.proof.invocationTarget = did;
         const s = await jsigs.sign(mockOperation, {
-
           documentLoader,
           suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
-          purpose: new CapabilityInvocation({capability: did, capabilityAction})
+          purpose: new CapabilityInvocation({
+            capability: did,
+            capabilityAction,
+            invocationTarget: did
+          })
         });
         const result = await voValidator.validate({
           basisBlockHeight: 10,

--- a/test/mocha/05-validate-async.js
+++ b/test/mocha/05-validate-async.js
@@ -859,21 +859,24 @@ describe('validate regular DIDs', () => {
       });
       mockOperation.recordPatch.patch = jsonpatch.generate(observer);
       mockOperation.recordPatch.target = did;
+      // after proof, change the patch target
+      const {did: did2} = await _generateDid();
       // FIXME: add a write proof for the accelerator that will pass
       // json-schema validation for testnet v2 *not* a valid signature
       mockOperation.proof = clone(mockData.proof);
-      mockOperation.proof.invocationTarget = did;
       const s = await jsigs.sign(mockOperation, {
         documentLoader,
         suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
         purpose: new CapabilityInvocation({
           capability: did,
           capabilityAction,
-          invocationTarget: did
+          // Set the invocation target to did2 here
+          // in order to have the correct expectedTarget in the validator below.
+          // This is purely to test that the validator throws if
+          // the operation has been modified
+          invocationTarget: did2
         })
       });
-      // after proof, change the patch target
-      const {did: did2} = await _generateDid();
       mockOperation.recordPatch.target = did2;
       const result = await voValidator.validate({
         basisBlockHeight: 10,
@@ -984,14 +987,13 @@ describe('validate regular DIDs', () => {
       // FIXME: add a write proof for the accelerator that will pass
       // json-schema validation for testnet v2 *not* a valid signature
       mockOperation.proof = clone(mockData.proof);
-      mockOperation.proof.invocationTarget = did;
       const s = await jsigs.sign(mockOperation, {
         documentLoader,
         suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
         purpose: new CapabilityInvocation({
           capability: did,
           capabilityAction,
-          invocationTarget: did
+          invocationTarget: did1
         })
       });
       const result = await voValidator.validate({

--- a/test/mocha/05-validate-async.js
+++ b/test/mocha/05-validate-async.js
@@ -1103,8 +1103,6 @@ describe('validate regular DIDs', () => {
       const capabilityInvocationKey =
         mockDoc.methodFor({purpose: 'capabilityInvocation'});
 
-      const keyId = mockDoc.getVerificationMethod(
-        {proofPurpose: 'capabilityInvocation'}).id;
       // add a write proof for the ledger that will pass json-schema
       // validation for testnet v2 *not* a valid signature
       mockOperation.proof = clone(mockData.proof);
@@ -1154,8 +1152,6 @@ describe('validate regular DIDs', () => {
 
       const capabilityInvocationKey =
         mockDoc.methodFor({purpose: 'capabilityInvocation'});
-      const keyId = mockDoc.getVerificationMethod(
-        {proofPurpose: 'capabilityInvocation'}).id;
       // add a write proof that will pass json-schema
       // validation for testnet v2 *not* a valid signature
       mockOperation.proof = clone(mockData.proof);

--- a/test/mocha/15-validate-elector-pool.js
+++ b/test/mocha/15-validate-elector-pool.js
@@ -218,7 +218,7 @@ describe('validate API ElectorPool', () => {
         result.valid.should.be.false;
         result.error.name.should.equal('ValidationError');
       });
-      it('fails on op w/two create capability proofs', async () => {
+      it('fails on op w/ two create capability proofs', async () => {
         const electorPoolDoc = _generateElectorPoolDoc();
         let operation = await _wrap(
           {didDocument: electorPoolDoc, operationType: 'create'});
@@ -307,7 +307,7 @@ describe('validate API ElectorPool', () => {
         result.valid.should.be.false;
         result.error.name.should.equal('ValidationError');
       });
-      it('fails on op w/incorrect capability DID', async () => {
+      it('fails on op w/ incorrect capability DID', async () => {
         const electorPoolDoc = _generateElectorPoolDoc();
         let operation = await _wrap(
           {didDocument: electorPoolDoc, operationType: 'create'});
@@ -338,6 +338,8 @@ describe('validate API ElectorPool', () => {
           // corresponds to electorPoolDocument.alpha
           electorPool: electorPoolDoc.id,
         };
+        // remove the mock proof before validating
+        operation.proof = [operation.proof[1]];
         let err;
         let result;
         try {

--- a/test/mocha/15-validate-elector-pool.js
+++ b/test/mocha/15-validate-elector-pool.js
@@ -49,7 +49,7 @@ describe('validate API ElectorPool', () => {
         operation = await attachInvocationProof(operation, {
           // capability: maintainerDid,
           capability: electorPoolDoc.id,
-          capabilityAction: 'create',
+          capabilityAction: 'write',
           key,
           signer: key.signer()
         });
@@ -103,7 +103,7 @@ describe('validate API ElectorPool', () => {
         operation.proof = bedrock.util.clone(mockData.proof);
         operation = await attachInvocationProof(operation, {
           capability: electorPoolDoc.id,
-          capabilityAction: 'create',
+          capabilityAction: 'write',
           key,
           signer: key.signer()
         });
@@ -139,7 +139,7 @@ describe('validate API ElectorPool', () => {
         result.valid.should.be.false;
         result.error.name.should.equal('NotFoundError');
       });
-      it('fails on op w/missing create capability', async () => {
+      it('fails on op if proof is not an array', async () => {
         const {id: maintainerDid} = maintainerDidDocumentFull.didDocument;
         const electorPoolDoc = _generateElectorPoolDoc();
         let operation = await _wrap(
@@ -147,10 +147,9 @@ describe('validate API ElectorPool', () => {
         const key = _getMaintainerKeys();
 
         // no create proof added
-
         operation = await attachInvocationProof(operation, {
           capability: maintainerDid,
-          capabilityAction: 'AuthorizeRequest',
+          capabilityAction: 'write',
           key,
         });
         const ledgerConfig = bedrock.util.clone(
@@ -191,7 +190,7 @@ describe('validate API ElectorPool', () => {
 
         operation = await attachInvocationProof(operation, {
           capability: maintainerDid,
-          capabilityAction: 'create',
+          capabilityAction: 'write',
           key,
         });
         const ledgerConfig = bedrock.util.clone(
@@ -229,12 +228,12 @@ describe('validate API ElectorPool', () => {
 
         operation = await attachInvocationProof(operation, {
           capability: electorPoolDoc.id,
-          capabilityAction: 'create',
+          capabilityAction: 'write',
           key,
         });
         operation = await attachInvocationProof(operation, {
           capability: electorPoolDoc.id,
-          capabilityAction: 'create',
+          capabilityAction: 'write',
           key,
         });
         const ledgerConfig = bedrock.util.clone(
@@ -274,13 +273,13 @@ describe('validate API ElectorPool', () => {
         operation = await attachInvocationProof(operation, {
           algorithm: 'Ed25519Signature2018',
           capability: maintainerDid,
-          capabilityAction: 'AuthorizeRequest',
+          capabilityAction: 'write',
           key,
         });
         operation = await attachInvocationProof(operation, {
           algorithm: 'Ed25519Signature2018',
           capability: maintainerDid,
-          capabilityAction: 'AuthorizeRequest',
+          capabilityAction: 'write',
           key,
         });
         const ledgerConfig = bedrock.util.clone(
@@ -322,7 +321,7 @@ describe('validate API ElectorPool', () => {
         operation = await attachInvocationProof(operation, {
           // this DID document does not exist
           capability: 'did:v1:uuid:e798d4cf-f4f5-40cb-9f06-7fa56cf55d95',
-          capabilityAction: 'create',
+          capabilityAction: 'write',
           key,
         });
 
@@ -426,7 +425,7 @@ describe('validate API ElectorPool', () => {
         operation = await attachInvocationProof(operation, {
           capability: electorPoolDoc.id,
           // capabilityAction: operation.type,
-          capabilityAction: 'update',
+          capabilityAction: 'write',
           key,
         });
         // FIXME: replace mock proof above with legitimate proof
@@ -503,7 +502,7 @@ describe('validate API ElectorPool', () => {
         operation = await attachInvocationProof(operation, {
           capability: electorPoolDoc.id,
           // capabilityAction: operation.type,
-          capabilityAction: 'update',
+          capabilityAction: 'write',
           key,
         });
         // FIXME: replace mock proof above with legitimate proof

--- a/test/mocha/15-validate-elector-pool.js
+++ b/test/mocha/15-validate-elector-pool.js
@@ -339,8 +339,6 @@ describe('validate API ElectorPool', () => {
           // corresponds to electorPoolDocument.alpha
           electorPool: electorPoolDoc.id,
         };
-        // remove the mock proof before validating
-        operation.proof = [operation.proof[1]];
         let err;
         let result;
         try {

--- a/test/mocha/15-validate-elector-pool.js
+++ b/test/mocha/15-validate-elector-pool.js
@@ -102,6 +102,8 @@ describe('validate API ElectorPool', () => {
         const key = _getMaintainerKeys();
         // FIXME: add a write proof for the ledger that will pass json-schema
         // validation for testnet v2 *not* a valid signature
+        operation.proof = bedrock.util.clone(mockData.proof);
+        operation.proof.invocationTarget = operation.record.id;
         operation = await attachInvocationProof({
           operation,
           // capability: maintainerDid,
@@ -111,7 +113,6 @@ describe('validate API ElectorPool', () => {
           key,
           signer: key.signer()
         });
-
         // FIXME: attach proof instead of mock proof above
         // operation = await attachInvocationProof(operation, {
         //   capability: maintainerDid,
@@ -228,7 +229,9 @@ describe('validate API ElectorPool', () => {
         result.valid.should.be.false;
         result.error.name.should.equal('ValidationError');
       });
-      it('fails on op w/ two write capability proofs', async () => {
+      // FIXME add validation to ensure one of the proof's invocationTarget
+      // is the ledger itself.
+      it.skip('fails on op w/ two write capability proofs', async () => {
         const electorPoolDoc = _generateElectorPoolDoc();
         let operation = await _wrap(
           {didDocument: electorPoolDoc, operationType: 'create'});
@@ -276,6 +279,7 @@ describe('validate API ElectorPool', () => {
         result.valid.should.be.false;
         result.error.name.should.equal('ValidationError');
       });
+      // FIXME false negative here
       it('fails on op w/two ledger write capability proofs', async () => {
         const {id: maintainerDid} = maintainerDidDocumentFull.didDocument;
         const electorPoolDoc = _generateElectorPoolDoc();
@@ -285,13 +289,12 @@ describe('validate API ElectorPool', () => {
 
         // we have 2 ledger write proofs, but no did specific
         // write proof
-
         operation = await attachInvocationProof({
           operation,
           algorithm: 'Ed25519Signature2018',
           capability: maintainerDid,
           capabilityAction: 'write',
-          invocationTarget: operation.record.id,
+          invocationTarget: maintainerDid,
           key,
         });
         operation = await attachInvocationProof({

--- a/test/mocha/15-validate-elector-pool.js
+++ b/test/mocha/15-validate-elector-pool.js
@@ -43,7 +43,7 @@ describe('validate API ElectorPool', () => {
           {didDocument: electorPoolDoc, operationType: 'create'});
         const key = _getMaintainerKeys();
 
-        // FIXME: add an AuthorizeRequest proof that will pass json-schema
+        // FIXME: add a write proof for the ledger that will pass json-schema
         // validation for testnet v2 *not* a valid signature
         operation.proof = bedrock.util.clone(mockData.proof);
         operation = await attachInvocationProof(operation, {
@@ -98,7 +98,7 @@ describe('validate API ElectorPool', () => {
           {didDocument: electorPoolDoc, operationType: 'create'});
         const key = _getMaintainerKeys();
 
-        // FIXME: add an AuthorizeRequest proof that will pass json-schema
+        // FIXME: add a write proof for the ledger that will pass json-schema
         // validation for testnet v2 *not* a valid signature
         operation.proof = bedrock.util.clone(mockData.proof);
         operation = await attachInvocationProof(operation, {
@@ -179,15 +179,14 @@ describe('validate API ElectorPool', () => {
         result.error.name.should.equal('ValidationError');
       });
 
-      it('fails on op w/missing AuthorizeRequest capability', async () => {
+      it('fails on op w/only one write capability', async () => {
         const {id: maintainerDid} = maintainerDidDocumentFull.didDocument;
         const electorPoolDoc = _generateElectorPoolDoc();
         let operation = await _wrap(
           {didDocument: electorPoolDoc, operationType: 'create'});
         const key = _getMaintainerKeys();
-
-        // no AuthorizeRequest proof added
-
+        // no ledger write proof added
+        // this proof is for writing to a single did
         operation = await attachInvocationProof(operation, {
           capability: maintainerDid,
           capabilityAction: 'write',
@@ -218,14 +217,15 @@ describe('validate API ElectorPool', () => {
         result.valid.should.be.false;
         result.error.name.should.equal('ValidationError');
       });
-      it('fails on op w/ two create capability proofs', async () => {
+      it('fails on op w/ two write capability proofs', async () => {
         const electorPoolDoc = _generateElectorPoolDoc();
         let operation = await _wrap(
           {didDocument: electorPoolDoc, operationType: 'create'});
         const key = _getMaintainerKeys();
 
-        // no AuthorizeRequest proof added
-
+        // no ledger write proof added
+        // this operation has 2 write proofs with dids, but no
+        // proof for writing to the ledger itself
         operation = await attachInvocationProof(operation, {
           capability: electorPoolDoc.id,
           capabilityAction: 'write',
@@ -261,14 +261,15 @@ describe('validate API ElectorPool', () => {
         result.valid.should.be.false;
         result.error.name.should.equal('ValidationError');
       });
-      it('fails on op w/two AuthorizeRequest capability proofs', async () => {
+      it('fails on op w/two ledger write capability proofs', async () => {
         const {id: maintainerDid} = maintainerDidDocumentFull.didDocument;
         const electorPoolDoc = _generateElectorPoolDoc();
         let operation = await _wrap(
           {didDocument: electorPoolDoc, operationType: 'create'});
         const key = _getMaintainerKeys();
 
-        // no create proof added
+        // we have 2 ledger write proofs, but no did specific
+        // write proof
 
         operation = await attachInvocationProof(operation, {
           algorithm: 'Ed25519Signature2018',
@@ -313,7 +314,7 @@ describe('validate API ElectorPool', () => {
           {didDocument: electorPoolDoc, operationType: 'create'});
         const key = _getMaintainerKeys();
 
-        // FIXME: add an AuthorizeRequest proof that will pass json-schema
+        // FIXME: add a write proof for the ledger that will pass json-schema
         // validation for testnet v2 *not* a valid signature
         operation.proof = bedrock.util.clone(mockData.proof);
 
@@ -420,7 +421,7 @@ describe('validate API ElectorPool', () => {
 
         // FIXME: what are proper proofs for an update operation?
 
-        // FIXME: add an AuthorizeRequest proof that will pass json-schema
+        // FIXME: add a write proof for the ledger that will pass json-schema
         // validation for testnet v2 *not* a valid signature
         operation.proof = bedrock.util.clone(mockData.proof);
 
@@ -497,7 +498,7 @@ describe('validate API ElectorPool', () => {
 
         // FIXME: what are proper proofs for an update operation?
 
-        // FIXME: add an AuthorizeRequest proof that will pass json-schema
+        // FIXME: add a write proof for the ledger that will pass json-schema
         // validation for testnet v2 *not* a valid signature
         operation.proof = bedrock.util.clone(mockData.proof);
 

--- a/test/mocha/15-validate-elector-pool.js
+++ b/test/mocha/15-validate-elector-pool.js
@@ -100,10 +100,8 @@ describe('validate API ElectorPool', () => {
         let operation = await _wrap(
           {didDocument: electorPoolDoc, operationType: 'create'});
         const key = _getMaintainerKeys();
-
         // FIXME: add a write proof for the ledger that will pass json-schema
         // validation for testnet v2 *not* a valid signature
-        operation.proof.invocationTarget = operation.record.id;
         operation = await attachInvocationProof({
           operation,
           // capability: maintainerDid,

--- a/test/mocha/15-validate-elector-pool.js
+++ b/test/mocha/15-validate-elector-pool.js
@@ -46,7 +46,7 @@ describe('validate API ElectorPool', () => {
         // FIXME: add a write proof for the ledger that will pass json-schema
         // validation for testnet v2 *not* a valid signature
         operation.proof = bedrock.util.clone(mockData.proof);
-        operation.proof.invocationTarget = operation.record.id;
+
         operation = await attachInvocationProof({
           operation,
           // capability: maintainerDid,
@@ -103,7 +103,7 @@ describe('validate API ElectorPool', () => {
         // FIXME: add a write proof for the ledger that will pass json-schema
         // validation for testnet v2 *not* a valid signature
         operation.proof = bedrock.util.clone(mockData.proof);
-        operation.proof.invocationTarget = operation.record.id;
+
         operation = await attachInvocationProof({
           operation,
           // capability: maintainerDid,

--- a/test/mocha/15-validate-elector-pool.js
+++ b/test/mocha/15-validate-elector-pool.js
@@ -46,10 +46,13 @@ describe('validate API ElectorPool', () => {
         // FIXME: add a write proof for the ledger that will pass json-schema
         // validation for testnet v2 *not* a valid signature
         operation.proof = bedrock.util.clone(mockData.proof);
-        operation = await attachInvocationProof(operation, {
+        operation.proof.invocationTarget = operation.record.id;
+        operation = await attachInvocationProof({
+          operation,
           // capability: maintainerDid,
           capability: electorPoolDoc.id,
           capabilityAction: 'write',
+          invocationTarget: operation.record.id,
           key,
           signer: key.signer()
         });
@@ -100,10 +103,13 @@ describe('validate API ElectorPool', () => {
 
         // FIXME: add a write proof for the ledger that will pass json-schema
         // validation for testnet v2 *not* a valid signature
-        operation.proof = bedrock.util.clone(mockData.proof);
-        operation = await attachInvocationProof(operation, {
+        operation.proof.invocationTarget = operation.record.id;
+        operation = await attachInvocationProof({
+          operation,
+          // capability: maintainerDid,
           capability: electorPoolDoc.id,
           capabilityAction: 'write',
+          invocationTarget: operation.record.id,
           key,
           signer: key.signer()
         });
@@ -145,13 +151,16 @@ describe('validate API ElectorPool', () => {
         let operation = await _wrap(
           {didDocument: electorPoolDoc, operationType: 'create'});
         const key = _getMaintainerKeys();
-
         // no create proof added
-        operation = await attachInvocationProof(operation, {
+        operation = await attachInvocationProof({
+          operation,
           capability: maintainerDid,
           capabilityAction: 'write',
+          invocationTarget: operation.record.id,
           key,
+          signer: key.signer()
         });
+
         const ledgerConfig = bedrock.util.clone(
           mockData.ledgerConfigurations.alpha);
         ledgerConfig.electorSelectionMethod = {
@@ -187,11 +196,15 @@ describe('validate API ElectorPool', () => {
         const key = _getMaintainerKeys();
         // no ledger write proof added
         // this proof is for writing to a single did
-        operation = await attachInvocationProof(operation, {
+        operation = await attachInvocationProof({
+          operation,
           capability: maintainerDid,
           capabilityAction: 'write',
+          invocationTarget: operation.record.id,
           key,
+          signer: key.signer()
         });
+
         const ledgerConfig = bedrock.util.clone(
           mockData.ledgerConfigurations.alpha);
         ledgerConfig.electorSelectionMethod = {
@@ -226,14 +239,18 @@ describe('validate API ElectorPool', () => {
         // no ledger write proof added
         // this operation has 2 write proofs with dids, but no
         // proof for writing to the ledger itself
-        operation = await attachInvocationProof(operation, {
+        operation = await attachInvocationProof({
+          operation,
           capability: electorPoolDoc.id,
           capabilityAction: 'write',
+          invocationTarget: electorPoolDoc.id,
           key,
         });
-        operation = await attachInvocationProof(operation, {
+        operation = await attachInvocationProof({
+          operation,
           capability: electorPoolDoc.id,
           capabilityAction: 'write',
+          invocationTarget: electorPoolDoc.id,
           key,
         });
         const ledgerConfig = bedrock.util.clone(
@@ -271,16 +288,20 @@ describe('validate API ElectorPool', () => {
         // we have 2 ledger write proofs, but no did specific
         // write proof
 
-        operation = await attachInvocationProof(operation, {
+        operation = await attachInvocationProof({
+          operation,
           algorithm: 'Ed25519Signature2018',
           capability: maintainerDid,
           capabilityAction: 'write',
+          invocationTarget: operation.record.id,
           key,
         });
-        operation = await attachInvocationProof(operation, {
+        operation = await attachInvocationProof({
+          operation,
           algorithm: 'Ed25519Signature2018',
           capability: maintainerDid,
           capabilityAction: 'write',
+          invocationTarget: operation.record.id,
           key,
         });
         const ledgerConfig = bedrock.util.clone(
@@ -319,10 +340,12 @@ describe('validate API ElectorPool', () => {
         operation.proof = bedrock.util.clone(mockData.proof);
 
         // replacing electorDid with maintainerDid
-        operation = await attachInvocationProof(operation, {
+        operation = await attachInvocationProof({
+          operation,
           // this DID document does not exist
           capability: 'did:v1:uuid:e798d4cf-f4f5-40cb-9f06-7fa56cf55d95',
           capabilityAction: 'write',
+          invocationTarget: operation.record.id,
           key,
         });
 
@@ -423,10 +446,12 @@ describe('validate API ElectorPool', () => {
         // validation for testnet v2 *not* a valid signature
         operation.proof = bedrock.util.clone(mockData.proof);
 
-        operation = await attachInvocationProof(operation, {
+        operation = await attachInvocationProof({
+          operation,
           capability: electorPoolDoc.id,
           // capabilityAction: operation.type,
           capabilityAction: 'write',
+          invocationTarget: operation.recordPatch.target,
           key,
         });
         // FIXME: replace mock proof above with legitimate proof
@@ -500,10 +525,12 @@ describe('validate API ElectorPool', () => {
         // validation for testnet v2 *not* a valid signature
         operation.proof = bedrock.util.clone(mockData.proof);
 
-        operation = await attachInvocationProof(operation, {
+        operation = await attachInvocationProof({
+          operation,
           capability: electorPoolDoc.id,
           // capabilityAction: operation.type,
           capabilityAction: 'write',
+          invocationTarget: operation.recordPatch.target,
           key,
         });
         // FIXME: replace mock proof above with legitimate proof

--- a/test/mocha/15-validate-elector-pool.js
+++ b/test/mocha/15-validate-elector-pool.js
@@ -57,7 +57,7 @@ describe('validate API ElectorPool', () => {
         // FIXME: attach proof instead of mock proof above
         // operation = await attachInvocationProof(operation, {
         //   capability: maintainerDid,
-        //   capabilityAction: 'AuthorizeRequest',
+        //   capabilityAction: 'write',
         //   key,
         // });
         const ledgerConfig = bedrock.util.clone(
@@ -111,7 +111,7 @@ describe('validate API ElectorPool', () => {
         // FIXME: attach proof instead of mock proof above
         // operation = await attachInvocationProof(operation, {
         //   capability: maintainerDid,
-        //   capabilityAction: 'AuthorizeRequest',
+        //   capabilityAction: 'write',
         //   key,
         // });
         const ledgerConfig = bedrock.util.clone(
@@ -328,7 +328,7 @@ describe('validate API ElectorPool', () => {
         // FIXME: attach proof instead of mock proof above
         // operation = await attachInvocationProof(operation, {
         //   capability: maintainerDid,
-        //   capabilityAction: 'AuthorizeRequest',
+        //   capabilityAction: 'write',
         //   key,
         // });
         const ledgerConfig = bedrock.util.clone(
@@ -432,7 +432,7 @@ describe('validate API ElectorPool', () => {
         // operation = await attachInvocationProof(operation, {
         //   capability: maintainerDid,
         //   // capabilityAction: operation.type,
-        //   capabilityAction: 'AuthorizeRequest',
+        //   capabilityAction: 'write',
         //   key,
         // });
         const ledgerConfig = bedrock.util.clone(
@@ -509,7 +509,7 @@ describe('validate API ElectorPool', () => {
         // operation = await attachInvocationProof(operation, {
         //   capability: maintainerDid,
         //   // capabilityAction: operation.type,
-        //   capabilityAction: 'AuthorizeRequest',
+        //   capabilityAction: 'write',
         //   key,
         // });
         const ledgerConfig = bedrock.util.clone(

--- a/test/mocha/17-validate-validator-parameter-set.js
+++ b/test/mocha/17-validate-validator-parameter-set.js
@@ -59,7 +59,7 @@ describe('validate API ValidatorParameterSet', () => {
         // FIXME: attach proof instead of mock proof above
         // operation = await attachInvocationProof(operation, {
         //   capability: maintainerDid,
-        //   capabilityAction: 'AuthorizeRequest',
+        //   capabilityAction: 'write',
         //   key,
         // });
         const ledgerConfig = clone(mockData.ledgerConfigurations.alpha);
@@ -106,7 +106,7 @@ describe('validate API ValidatorParameterSet', () => {
         // FIXME: attach proof instead of mock proof above
         // operation = await attachInvocationProof(operation, {
         //   capability: maintainerDid,
-        //   capabilityAction: 'AuthorizeRequest',
+        //   capabilityAction: 'write',
         //   key,
         // });
         const ledgerConfig = clone(mockData.ledgerConfigurations.alpha);
@@ -161,7 +161,7 @@ describe('validate API ValidatorParameterSet', () => {
         // FIXME: attach proof instead of mock proof above
         // operation = await attachInvocationProof(operation, {
         //   capability: maintainerDid,
-        //   capabilityAction: 'AuthorizeRequest',
+        //   capabilityAction: 'write',
         //   key,
         // });
         const ledgerConfig = clone(mockData.ledgerConfigurations.alpha);
@@ -234,7 +234,7 @@ describe('validate API ValidatorParameterSet', () => {
         // operation = await attachInvocationProof(operation, {
         //   capability: maintainerDid,
         //   // capabilityAction: operation.type,
-        //   capabilityAction: 'AuthorizeRequest',
+        //   capabilityAction: 'write',
         //   key,
         // });
         const ledgerConfig = clone(mockData.ledgerConfigurations.alpha);
@@ -301,7 +301,7 @@ describe('validate API ValidatorParameterSet', () => {
         // operation = await attachInvocationProof(operation, {
         //   capability: maintainerDid,
         //   // capabilityAction: operation.type,
-        //   capabilityAction: 'AuthorizeRequest',
+        //   capabilityAction: 'write',
         //   key,
         // });
         const ledgerConfig = clone(mockData.ledgerConfigurations.alpha);
@@ -372,7 +372,7 @@ describe('validate API ValidatorParameterSet', () => {
         // operation = await attachInvocationProof(operation, {
         //   capability: maintainerDid,
         //   // capabilityAction: operation.type,
-        //   capabilityAction: 'AuthorizeRequest',
+        //   capabilityAction: 'write',
         //   key,
         // });
         const ledgerConfig = clone(mockData.ledgerConfigurations.alpha);
@@ -443,7 +443,7 @@ describe('validate API ValidatorParameterSet', () => {
         // operation = await attachInvocationProof(operation, {
         //   capability: maintainerDid,
         //   // capabilityAction: operation.type,
-        //   capabilityAction: 'AuthorizeRequest',
+        //   capabilityAction: 'write',
         //   key,
         // });
         const ledgerConfig = clone(mockData.ledgerConfigurations.alpha);

--- a/test/mocha/17-validate-validator-parameter-set.js
+++ b/test/mocha/17-validate-validator-parameter-set.js
@@ -45,7 +45,7 @@ describe('validate API ValidatorParameterSet', () => {
           {didDocument: validatorParameterSetDoc, operationType: 'create'});
         const key = _getMaintainerKeys();
 
-        // FIXME: add an AuthorizeRequest proof that will pass json-schema
+        // FIXME: add a write proof for the ledger that will pass json-schema
         // validation for testnet v2 *not* a valid signature
         operation.proof = clone(mockData.proof);
 
@@ -92,7 +92,7 @@ describe('validate API ValidatorParameterSet', () => {
           {didDocument: validatorParameterSetDoc, operationType: 'create'});
         const key = _getMaintainerKeys();
 
-        // FIXME: add an AuthorizeRequest proof that will pass json-schema
+        // FIXME: add a write proof for the ledger that will pass json-schema
         // validation for testnet v2 *not* a valid signature
         operation.proof = clone(mockData.proof);
 
@@ -147,7 +147,7 @@ describe('validate API ValidatorParameterSet', () => {
           {didDocument: validatorParameterSetDoc, operationType: 'create'});
         const key = _getMaintainerKeys();
 
-        // FIXME: add an AuthorizeRequest proof that will pass json-schema
+        // FIXME: add a write proof for the ledger that will pass json-schema
         // validation for testnet v2 *not* a valid signature
         operation.proof = clone(mockData.proof);
 
@@ -220,7 +220,7 @@ describe('validate API ValidatorParameterSet', () => {
 
         // FIXME: what are proper proofs for an update operation?
 
-        // FIXME: add an AuthorizeRequest proof that will pass json-schema
+        // FIXME: add a write proof for the ledger that will pass json-schema
         // validation for testnet v2 *not* a valid signature
         operation.proof = clone(mockData.proof);
 
@@ -287,7 +287,7 @@ describe('validate API ValidatorParameterSet', () => {
 
         // FIXME: what are proper proofs for an update operation?
 
-        // FIXME: add an AuthorizeRequest proof that will pass json-schema
+        // FIXME: add a write proof for the ledger that will pass json-schema
         // validation for testnet v2 *not* a valid signature
         operation.proof = clone(mockData.proof);
 
@@ -358,7 +358,7 @@ describe('validate API ValidatorParameterSet', () => {
 
         // FIXME: what are proper proofs for an update operation?
 
-        // FIXME: add an AuthorizeRequest proof that will pass json-schema
+        // FIXME: add a write proof for the ledger that will pass json-schema
         // validation for testnet v2 *not* a valid signature
         operation.proof = clone(mockData.proof);
 
@@ -429,7 +429,7 @@ describe('validate API ValidatorParameterSet', () => {
 
         // FIXME: what are proper proofs for an update operation?
 
-        // FIXME: add an AuthorizeRequest proof that will pass json-schema
+        // FIXME: add a write proof for the ledger that will pass json-schema
         // validation for testnet v2 *not* a valid signature
         operation.proof = clone(mockData.proof);
 

--- a/test/mocha/17-validate-validator-parameter-set.js
+++ b/test/mocha/17-validate-validator-parameter-set.js
@@ -444,7 +444,6 @@ describe('validate API ValidatorParameterSet', () => {
         // FIXME: add a write proof for the ledger that will pass json-schema
         // validation for testnet v2 *not* a valid signature
         operation.proof = clone(mockData.proof);
-
         operation = await attachInvocationProof({
           operation,
           capability: validatorParameterSetDoc.id,

--- a/test/mocha/17-validate-validator-parameter-set.js
+++ b/test/mocha/17-validate-validator-parameter-set.js
@@ -52,7 +52,7 @@ describe('validate API ValidatorParameterSet', () => {
         operation = await attachInvocationProof(operation, {
           // capability: maintainerDid,
           capability: validatorParameterSetDoc.id,
-          capabilityAction: 'create',
+          capabilityAction: 'write',
           key,
         });
 
@@ -99,7 +99,7 @@ describe('validate API ValidatorParameterSet', () => {
         operation = await attachInvocationProof(operation, {
           // capability: maintainerDid,
           capability: validatorParameterSetDoc.id,
-          capabilityAction: 'create',
+          capabilityAction: 'write',
           key,
         });
 
@@ -154,7 +154,7 @@ describe('validate API ValidatorParameterSet', () => {
         operation = await attachInvocationProof(operation, {
           // capability: maintainerDid,
           capability: validatorParameterSetDoc.id,
-          capabilityAction: 'create',
+          capabilityAction: 'write',
           key,
         });
 
@@ -227,7 +227,7 @@ describe('validate API ValidatorParameterSet', () => {
         operation = await attachInvocationProof(operation, {
           capability: validatorParameterSetDoc.id,
           // capabilityAction: operation.type,
-          capabilityAction: 'update',
+          capabilityAction: 'write',
           key,
         });
         // FIXME: replace mock proof above with legitimate proof
@@ -294,7 +294,7 @@ describe('validate API ValidatorParameterSet', () => {
         operation = await attachInvocationProof(operation, {
           capability: validatorParameterSetDoc.id,
           // capabilityAction: operation.type,
-          capabilityAction: 'update',
+          capabilityAction: 'write',
           key,
         });
         // FIXME: replace mock proof above with legitimate proof
@@ -365,7 +365,7 @@ describe('validate API ValidatorParameterSet', () => {
         operation = await attachInvocationProof(operation, {
           capability: validatorParameterSetDoc.id,
           // capabilityAction: operation.type,
-          capabilityAction: 'update',
+          capabilityAction: 'write',
           key,
         });
         // FIXME: replace mock proof above with legitimate proof
@@ -436,7 +436,7 @@ describe('validate API ValidatorParameterSet', () => {
         operation = await attachInvocationProof(operation, {
           capability: validatorParameterSetDoc.id,
           // capabilityAction: operation.type,
-          capabilityAction: 'update',
+          capabilityAction: 'write',
           key,
         });
         // FIXME: replace mock proof above with legitimate proof

--- a/test/mocha/17-validate-validator-parameter-set.js
+++ b/test/mocha/17-validate-validator-parameter-set.js
@@ -49,10 +49,12 @@ describe('validate API ValidatorParameterSet', () => {
         // validation for testnet v2 *not* a valid signature
         operation.proof = clone(mockData.proof);
 
-        operation = await attachInvocationProof(operation, {
+        operation = await attachInvocationProof({
+          operation,
           // capability: maintainerDid,
           capability: validatorParameterSetDoc.id,
           capabilityAction: 'write',
+          invocationTarget: operation.record.id,
           key,
         });
 
@@ -96,10 +98,12 @@ describe('validate API ValidatorParameterSet', () => {
         // validation for testnet v2 *not* a valid signature
         operation.proof = clone(mockData.proof);
 
-        operation = await attachInvocationProof(operation, {
+        operation = await attachInvocationProof({
+          operation,
           // capability: maintainerDid,
           capability: validatorParameterSetDoc.id,
           capabilityAction: 'write',
+          invocationTarget: operation.record.id,
           key,
         });
 
@@ -151,10 +155,12 @@ describe('validate API ValidatorParameterSet', () => {
         // validation for testnet v2 *not* a valid signature
         operation.proof = clone(mockData.proof);
 
-        operation = await attachInvocationProof(operation, {
+        operation = await attachInvocationProof({
+          operation,
           // capability: maintainerDid,
           capability: validatorParameterSetDoc.id,
           capabilityAction: 'write',
+          invocationTarget: operation.record.id,
           key,
         });
 
@@ -224,10 +230,12 @@ describe('validate API ValidatorParameterSet', () => {
         // validation for testnet v2 *not* a valid signature
         operation.proof = clone(mockData.proof);
 
-        operation = await attachInvocationProof(operation, {
+        operation = await attachInvocationProof({
+          operation,
           capability: validatorParameterSetDoc.id,
           // capabilityAction: operation.type,
           capabilityAction: 'write',
+          invocationTarget: operation.recordPatch.target,
           key,
         });
         // FIXME: replace mock proof above with legitimate proof
@@ -291,10 +299,12 @@ describe('validate API ValidatorParameterSet', () => {
         // validation for testnet v2 *not* a valid signature
         operation.proof = clone(mockData.proof);
 
-        operation = await attachInvocationProof(operation, {
+        operation = await attachInvocationProof({
+          operation,
           capability: validatorParameterSetDoc.id,
           // capabilityAction: operation.type,
           capabilityAction: 'write',
+          invocationTarget: operation.recordPatch.target,
           key,
         });
         // FIXME: replace mock proof above with legitimate proof
@@ -362,10 +372,12 @@ describe('validate API ValidatorParameterSet', () => {
         // validation for testnet v2 *not* a valid signature
         operation.proof = clone(mockData.proof);
 
-        operation = await attachInvocationProof(operation, {
+        operation = await attachInvocationProof({
+          operation,
           capability: validatorParameterSetDoc.id,
           // capabilityAction: operation.type,
           capabilityAction: 'write',
+          invocationTarget: operation.recordPatch.target,
           key,
         });
         // FIXME: replace mock proof above with legitimate proof
@@ -433,10 +445,12 @@ describe('validate API ValidatorParameterSet', () => {
         // validation for testnet v2 *not* a valid signature
         operation.proof = clone(mockData.proof);
 
-        operation = await attachInvocationProof(operation, {
+        operation = await attachInvocationProof({
+          operation,
           capability: validatorParameterSetDoc.id,
           // capabilityAction: operation.type,
           capabilityAction: 'write',
+          invocationTarget: operation.recordPatch.target,
           key,
         });
         // FIXME: replace mock proof above with legitimate proof

--- a/test/mocha/mock.data.js
+++ b/test/mocha/mock.data.js
@@ -46,6 +46,7 @@ mock.proof = {
   created: '2021-01-10T23:10:25Z',
   capability: 'did:v1:uuid:c37e914a-1e2a-4d59-9668-ee93458fd19a',
   capabilityAction: 'write',
+  invocationTarget: 'urn:zcap:root:ledger',
   proofPurpose: 'capabilityInvocation',
   proofValue: 'z3t9it5yhFHkqWnHKMQ2DWVj7aHDN37f95UzhQYQGYd9LyTSGzufCiTwDWN' +
     'fCdxQA9ZHcTTVAhHwoAji2AJnk2E6',

--- a/test/package.json
+++ b/test/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "test": "node --preserve-symlinks test test",
+    "debug": "node --preserve-symlinks test test --log-level debug",
     "coverage": "cross-env NODE_ENV=test nyc --reporter=lcov --reporter=text-summary npm test",
     "coverage-ci": "cross-env NODE_ENV=test nyc --reporter=lcov npm test",
     "coverage-report": "nyc report"

--- a/test/package.json
+++ b/test/package.json
@@ -10,6 +10,7 @@
     "coverage-report": "nyc report"
   },
   "dependencies": {
+    "@digitalbazaar/zcapld": "^5.0.0",
     "async": "^2.4.1",
     "bedrock": "^3.0.0",
     "bedrock-https-agent": "^1.0.0",

--- a/test/package.json
+++ b/test/package.json
@@ -22,7 +22,7 @@
     "bedrock-ledger-utils": "^1.0.0",
     "bedrock-mongodb": "^8.1.0",
     "bedrock-permission": "^3.0.0",
-    "bedrock-security-context": "^3.0.0",
+    "bedrock-security-context": "^4.1.0",
     "bedrock-test": "^5.3.0",
     "bedrock-validation": "^5.1.0",
     "bedrock-veres-one-context": "^11.0.0",

--- a/test/package.json
+++ b/test/package.json
@@ -28,7 +28,6 @@
     "bedrock-validation": "^5.1.0",
     "bedrock-veres-one-context": "^11.0.0",
     "cross-env": "^7.0.2",
-    "did-veres-one": "veres-one/did-veres-one#v14.x",
     "ed25519-signature-2020-context": "^1.1.0",
     "fast-json-patch": "^2.0.7",
     "grunt": "^1.0.1",


### PR DESCRIPTION
- [x] Remove `create` and `update`
- [x] Remove `authorizeRequest`
- [x] rebase with master
- [x] Figure out why mockProof must be removed from operations before validating now.
- [x]     // FIXME: Force first two items to be DID and V1 context?

Part of a cycle:

- [x] https://github.com/veres-one/veres-one/pull/44
- [x] https://github.com/veres-one/did-veres-one/pull/69