### PR TITLE
Use witness selection method

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -71,7 +71,7 @@ api.validate = async ({
     return result;
   }
 
-  const electorPool = _.get(ledgerConfig, 'electorSelectionMethod.electorPool');
+  const electorPool = _.get(ledgerConfig, 'witnessSelectionMethod.electorPool');
   const {validatorParameterSet} = validatorConfig;
 
   if(validatorInput.type === 'CreateWebLedgerRecord') {

--- a/lib/validators/updateWebLedgerRecord.js
+++ b/lib/validators/updateWebLedgerRecord.js
@@ -61,9 +61,9 @@ module.exports = async ({
     return _immutableValidationError(
       {key: 'type', originalDocument, patchedDocument});
   }
-  if(patchedDocument.type === 'ElectorPool') {
+  if(patchedDocument.type === 'WitnessPool') {
     const result = validate(
-      'veres-one-validator.electorPoolDocument', patchedDocument);
+      'veres-one-validator.witnessPoolDocument', patchedDocument);
     if(!result.valid) {
       return result;
     }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "peerDependencies": {
     "bedrock": "2.x - 3.x",
     "bedrock-jsonld-document-loader": "^1.0.0",
-    "bedrock-ledger-context": "^18.1.0",
+    "bedrock-ledger-context": "^19.0.0",
     "bedrock-ledger-node": "^10.0.0",
     "bedrock-ledger-utils": "^1.0.0",
     "bedrock-validation": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "peerDependencies": {
     "bedrock": "2.x - 3.x",
     "bedrock-jsonld-document-loader": "^1.0.0",
-    "bedrock-ledger-context": "^19.0.0",
+    "bedrock-ledger-context": "^20.0.1",
     "bedrock-ledger-node": "^10.0.0",
     "bedrock-ledger-utils": "^1.0.0",
     "bedrock-validation": "^5.1.0",

--- a/schemas/did-uuid.js
+++ b/schemas/did-uuid.js
@@ -3,24 +3,19 @@
  */
 'use strict';
 
-const bedrock = require('bedrock');
-const {config} = bedrock;
 require('../lib/config');
 
-const cfg = config['veres-one-validator'];
-
-const prefix = cfg.environment === 'test' ? 'did:v1:test' : 'did:v1';
 /* eslint-disable-next-line max-len */
-const pattern = `^${prefix}:uuid:([a-fA-F0-9]{8}-[a-fA-F0-9]{4}-4[a-fA-F0-9]{3}-[89abAB][a-fA-F0-9]{3}-[a-fA-F0-9]{12})$`;
-// prefix can be 11 chars or 6 chars for a total of 53 or 48
-const expectedLength = prefix.length + 42;
+const pattern = `^did:v1(:[a-z][a-z0-9]+)*:uuid:([a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12})$`;
+const minLength = 49; // did:v1:uuid:<UUID_VALUE>
+const maxLength = 66; // minLength + :<16_CHARACTER_NETWORK_ID>
 
 const schema = {
   title: 'DID UUID',
   type: 'string',
   pattern,
-  minLength: expectedLength,
-  maxLength: expectedLength
+  minLength,
+  maxLength
 };
 
 module.exports = () => schema;

--- a/schemas/did-uuid.js
+++ b/schemas/did-uuid.js
@@ -6,8 +6,9 @@
 require('../lib/config');
 
 /* eslint-disable-next-line max-len */
-const pattern = `^did:v1(:[a-z][a-z0-9]+)*:uuid:([a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12})$`;
-const minLength = 49; // did:v1:uuid:<UUID_VALUE>
+const pattern = '^did:v1(:[a-z][a-z0-9]+)*:uuid:' +
+  '([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})$';
+const minLength = 48; // did:v1:uuid:<UUID_VALUE>
 const maxLength = 66; // minLength + :<16_CHARACTER_NETWORK_ID>
 
 const schema = {

--- a/schemas/did.js
+++ b/schemas/did.js
@@ -3,15 +3,13 @@
  */
 'use strict';
 
-const bedrock = require('bedrock');
-const {config} = bedrock;
 require('../lib/config');
 
-const cfg = config['veres-one-validator'];
-const prefix = cfg.environment === 'test' ? 'did:v1:test' : 'did:v1';
-const pattern = `^(${prefix}:nym:)([-_A-Za-z0-9.]+)$`;
-// prefix + :nym:
-const minLength = prefix.length + 5;
+const pattern = '^did:v1(:[a-z][a-z0-9]+)*:nym:(z[A-Za-z1-9]+)$';
+// did:v1:nym:[48 base58 characters (z + 2 byte multicodec header + 32 bytes]
+const minLength = 59;
+// did:v1:[16 character network ID]:nym:[48 base58 characters]
+const maxLength = 77;
 
 const schema = {
   title: 'Decentralized Identifier',
@@ -19,8 +17,7 @@ const schema = {
   type: 'string',
   pattern,
   minLength,
-  // prefix plus a single multibase base58 encoded multicodec public key
-  maxLength: minLength + 48,
+  maxLength,
   errors: {
     invalid: 'The decentralized identifier is invalid.',
     missing: 'Please enter a decentralized identifier.'

--- a/schemas/didReference.js
+++ b/schemas/didReference.js
@@ -3,27 +3,23 @@
  */
 'use strict';
 
-const bedrock = require('bedrock');
-
-const {config} = bedrock;
 require('../lib/config');
 
-const cfg = config['veres-one-validator'];
-
 // a did reference contains an anchor tag `#`
-const pattern = cfg.environment === 'test' ?
-  '^(did\:v1\:test\:nym\:)(z[-_A-Za-z0-9.]+)#(z[-_A-Za-z0-9.]+)$' :
-  '^(did\:v1\:nym\:)(z[-_A-Za-z0-9.]+)#(z[-_A-Za-z0-9.]+)$';
+const pattern =
+ '^did:v1(:[a-z][a-z0-9]+)*:nym:(z[A-Za-z1-9]+)#(z[A-Za-z1-9]+)$';
+// did:v1:nym:[48 base58 characters]#[48 base58 characters]
+const minLength = 108;
+// did:v1[:[16 character network ID]:nym:z[32 bytes of base58 + 2 byte header]
+const maxLength = 126;
 
 const schema = {
   title: 'Decentralized Identifier',
   description: 'A decentralized identifier.',
   type: 'string',
   pattern,
-  minLength: cfg.environment === 'test' ? 17 : 12,
-  // prefix max length is 16 + 2x publicKeyMultibase (48 each) and
-  // a # in the middle for 113 characters
-  maxLength: 113,
+  minLength,
+  maxLength,
   errors: {
     invalid: 'The decentralized identifier reference is invalid.',
     missing: 'Please provide a decentralized identifier reference.'

--- a/schemas/veres-one-validator.js
+++ b/schemas/veres-one-validator.js
@@ -9,7 +9,7 @@ const {maxLength} = require('../lib/constants');
 const did = require('./did');
 const didReference = require('./didReference');
 const didUuid = require('./did-uuid');
-const {serviceDescriptor, serviceId} = require('./service');
+const {serviceDescriptor} = require('./service');
 const urnUuid = require('./urn-uuid');
 
 // can be a did or a url
@@ -17,43 +17,8 @@ const creator = {
   anyOf: [schemas.url(), did(), didReference(), didUuid()]
 };
 
-const caveat = {
-  additionalProperties: false,
-  required: [
-    'type'
-  ],
-  type: 'object',
-  properties: {
-    type: {
-      type: 'string',
-      maxLength
-      // FIXME: enable when term is finalized
-      // enum: ['VeresOneWitnessTicketAgent']
-    }
-  }
-};
-
 const invocationTarget = {
   anyOf: [did(), didUuid(), urnUuid()]
-};
-
-const capability = {
-  additionalProperties: false,
-  type: 'object',
-  required: [
-    'caveat',
-    'id',
-    'invocationTarget',
-  ],
-  properties: {
-    caveat: {
-      type: 'array',
-      minItems: 1,
-      items: caveat,
-    },
-    id: did(),
-    invocationTarget
-  }
 };
 
 const operationValidator = {
@@ -327,19 +292,6 @@ const didDocumentPatch = {
       maximum: Number.MAX_SAFE_INTEGER
     }
   },
-};
-
-const ContinuityWitnessTypes = {
-  type: 'string',
-  enum: [
-    'Continuity2017Witness',
-    'Continuity2017GuarantorWitness',
-  ],
-};
-
-const Continuity2017Witness = {
-  type: 'string',
-  enum: ['Continuity2017Witness'],
 };
 
 const witnessPoolDocument = {

--- a/schemas/veres-one-validator.js
+++ b/schemas/veres-one-validator.js
@@ -543,7 +543,7 @@ const ledgerConfiguration = {
   required: [
     '@context',
     'consensusMethod',
-    'electorSelectionMethod',
+    'witnessSelectionMethod',
     'ledger',
     'ledgerConfigurationValidator',
     'operationValidator',
@@ -559,7 +559,7 @@ const ledgerConfiguration = {
     ]),
     consensusMethod: {const: 'Continuity2017'},
     creator,
-    electorSelectionMethod: {
+    witnessSelectionMethod: {
       additionalProperties: false,
       required: [
         // maximumElectorCount is *not* required in the configuration

--- a/test/mocha/05-validate-async.js
+++ b/test/mocha/05-validate-async.js
@@ -245,7 +245,7 @@ describe('validate regular DIDs', () => {
 
     describe('Create DID with a service', () => {
       const validatorParameterSet =
-        'did:v1:uuid:b49fc147-5966-4407-a428-b597a77461ba';
+        'did:v1:test:uuid:b49fc147-5966-4407-a428-b597a77461ba';
       const validatorConfig = clone(mockData.ledgerConfigurations.alpha
         .operationValidator[0]);
       validatorConfig.validatorParameterSet = validatorParameterSet;
@@ -328,7 +328,7 @@ describe('validate regular DIDs', () => {
         const configMissingValidatorParameterSet = clone(validatorConfig);
         // this DID triggers a TerribleValidatorParameterSetError
         configMissingValidatorParameterSet.validatorParameterSet =
-          'did:v1:uuid:40aea416-73b2-436f-bb91-41175494d72b';
+          'did:v1:test:uuid:40aea416-73b2-436f-bb91-41175494d72b';
         const result = await voValidator.validate({
           basisBlockHeight: 0,
           ledgerNode: mockData.ledgerNode,
@@ -637,7 +637,7 @@ describe('validate regular DIDs', () => {
       const observer = jsonpatch.observe(mockDoc);
 
       mockDoc.id =
-        'did:v1:nym:z6MknY7qbTmVNPUC2xRyfSzcf3LxQGBx4t8uBVhGkKq7XXXX';
+        'did:v1:test:nym:z6MknY7qbTmVNPUC2xRyfSzcf3LxQGBx4t8uBVhGkKq7XXXX';
 
       const newKey = await Ed25519VerificationKey2020.generate({
         controller: did
@@ -1281,7 +1281,7 @@ describe('validate regular DIDs', () => {
 
     describe('Updates involving services', () => {
       const validatorParameterSet =
-        'did:v1:uuid:b49fc147-5966-4407-a428-b597a77461ba';
+        'did:v1:test:uuid:b49fc147-5966-4407-a428-b597a77461ba';
       const validatorConfig = clone(mockData.ledgerConfigurations.alpha
         .operationValidator[0]);
       validatorConfig.validatorParameterSet = validatorParameterSet;
@@ -1590,7 +1590,7 @@ async function _generateBadDid() {
   const capabilityInvocationKey = await Ed25519VerificationKey2020.generate();
   const keyFingerprint = capabilityInvocationKey.fingerprint();
 
-  const did = `did:v1:nym:${keyFingerprint}`;
+  const did = `did:v1:test:nym:${keyFingerprint}`;
   // cryptonym dids are based on fingerprint of capabilityInvokation key
   mockDoc.id = did;
   capabilityInvocationKey.id = _generateKeyId(
@@ -1611,7 +1611,7 @@ async function _generateDid() {
   const capabilityInvocationKey = await Ed25519VerificationKey2020.generate();
   const keyFingerprint = capabilityInvocationKey.fingerprint();
 
-  const did = `did:v1:nym:${keyFingerprint}`;
+  const did = `did:v1:test:nym:${keyFingerprint}`;
   // cryptonym dids are based on fingerprint of capabilityInvokation key
   mockDoc.id = did;
   capabilityInvocationKey.id = _generateKeyId(

--- a/test/mocha/05-validate-async.js
+++ b/test/mocha/05-validate-async.js
@@ -16,7 +16,7 @@ const voValidator = require('veres-one-validator');
 const {CapabilityInvocation} = require('@digitalbazaar/zcapld');
 const mockData = require('./mock.data');
 const {VeresOneDidDoc} = require('did-veres-one');
-const v1 = require('did-veres-one').driver();
+const v1 = require('did-veres-one').driver({mode: 'test'});
 
 const {util: {clone}} = bedrock;
 

--- a/test/mocha/12-validate-ledger-configuration.js
+++ b/test/mocha/12-validate-ledger-configuration.js
@@ -8,7 +8,7 @@ const {util: {clone}} = require('bedrock');
 const jsigs = require('jsonld-signatures');
 const mockData = require('./mock.data');
 const voValidator = require('veres-one-validator');
-const v1 = require('did-veres-one').driver();
+const v1 = require('did-veres-one').driver({mode: 'test'});
 const {Ed25519Signature2020} =
   require('@digitalbazaar/ed25519-signature-2020');
 const {purposes: {AssertionProofPurpose}} = jsigs;
@@ -38,10 +38,10 @@ describe('validate API WebLedgerConfiguration', () => {
     result.valid.should.be.a('boolean');
     result.valid.should.be.true;
   });
-  it('rejects a configuration w/missing electorSelectionMethod', async () => {
+  it('rejects a configuration w/missing witnessSelectionMethod', async () => {
     const ledgerConfiguration = clone(mockData.ledgerConfigurations.alpha);
 
-    delete ledgerConfiguration.electorSelectionMethod;
+    delete ledgerConfiguration.witnessSelectionMethod;
 
     // The public key material is derived from the nym DID because the
     // maintainers DID does not yet exist on the ledger

--- a/test/mocha/12-validate-ledger-configuration.js
+++ b/test/mocha/12-validate-ledger-configuration.js
@@ -134,7 +134,7 @@ describe('validate API WebLedgerConfiguration', () => {
       purpose: new AssertionProofPurpose()
     });
     s.proof.verificationMethod =
-      'did:v1:nym:z6MknbD3kDazNR5K5Aj9HtxsaqS1s2NUcTxescFdvZryECFx#' +
+      'did:v1:test:nym:z6MknbD3kDazNR5K5Aj9HtxsaqS1s2NUcTxescFdvZryECFx#' +
       '6MknbD3kDazNR5K5Aj9HtxsaqS1s2NUcTxescFdvZryECFx';
 
     const result = await voValidator.validate({
@@ -166,7 +166,7 @@ describe('validate API WebLedgerConfiguration', () => {
     });
 
     s.proof.verificationMethod =
-      'did:v1:nym:z6MksN1qAquFzdSgXwVTAYuuLGfckt3UpkhHwFwPsbSiwrUB#' +
+      'did:v1:test:nym:z6MksN1qAquFzdSgXwVTAYuuLGfckt3UpkhHwFwPsbSiwrUB#' +
       // the 9 here specifies a decimal encoding
       '91234';
 

--- a/test/mocha/15-validate-elector-pool.js
+++ b/test/mocha/15-validate-elector-pool.js
@@ -344,7 +344,7 @@ describe('validate API ElectorPool', () => {
         operation = await attachInvocationProof({
           operation,
           // this DID document does not exist
-          capability: 'did:v1:uuid:e798d4cf-f4f5-40cb-9f06-7fa56cf55d95',
+          capability: 'did:v1:test:uuid:e798d4cf-f4f5-40cb-9f06-7fa56cf55d95',
           capabilityAction: 'write',
           invocationTarget: operation.record.id,
           key,
@@ -405,7 +405,7 @@ describe('validate API ElectorPool', () => {
         ldDocuments.set(electorPoolDoc.id, bedrock.util.clone(electorPoolDoc));
         const observer = jsonpatch.observe(electorPoolDoc);
         const elector =
-          'did:v1:nym:z279squ73dJ3q21jAEk3FRrr37UdX5xo8FXWA74anmPnvzfx';
+          'did:v1:test:nym:z279squ73dJ3q21jAEk3FRrr37UdX5xo8FXWA74anmPnvzfx';
 
         // FIXME: should inline serviceIds be did: URI's?
         const newServiceId = `${elector};service=TheServiceId`;

--- a/test/mocha/15-validate-witness-pool.js
+++ b/test/mocha/15-validate-witness-pool.js
@@ -4,14 +4,12 @@
 'use strict';
 const {attachInvocationProof} = require('did-veres-one');
 const bedrock = require('bedrock');
-const {config: {constants}, util: {uuid, BedrockError}} = bedrock;
+const {config: {constants}, util: {BedrockError}} = bedrock;
 const helpers = require('./helpers');
 const {httpsAgent} = require('bedrock-https-agent');
 const v1 = require('did-veres-one').driver({httpsAgent});
 const voValidator = require('veres-one-validator');
 const jsonpatch = require('fast-json-patch');
-
-const continuityServiceType = 'Continuity2017Peer';
 
 const ldDocuments = new Map();
 const ledgerNode = helpers.createMockLedgerNode({ldDocuments});
@@ -19,7 +17,6 @@ const mockData = require('./mock.data');
 
 let maintainerDidDocumentFull;
 let witnessDidDocumentFull;
-let witnessServiceId;
 describe('validate API WitnessPool', () => {
   describe('operationValidator', () => {
     beforeEach(async () => {
@@ -28,7 +25,6 @@ describe('validate API WitnessPool', () => {
       ldDocuments.set(maintainerDidDocument.id, maintainerDidDocument);
       witnessDidDocumentFull = await v1.generate();
       const {didDocument: witnessDidDocument} = witnessDidDocumentFull;
-      witnessServiceId = `${witnessDidDocument.id}#MyServiceName`;
       ldDocuments.set(witnessDidDocument.id, witnessDidDocument);
     });
     describe('create witnessPool operation', () => {
@@ -564,10 +560,6 @@ function _generateWitnessPoolDoc() {
   witnessPoolDoc.maximumWitnessCount = 1;
   witnessPoolDoc.primaryWitnessCandidate = [witnessDid];
   return witnessPoolDoc;
-}
-
-function _generateUrnUuid() {
-  return `urn:uuid:${uuid()}`;
 }
 
 function _getMaintainerKeys() {

--- a/test/mocha/17-validate-validator-parameter-set.js
+++ b/test/mocha/17-validate-validator-parameter-set.js
@@ -12,8 +12,6 @@ const v1 = require('did-veres-one').driver({httpsAgent});
 const voValidator = require('veres-one-validator');
 const jsonpatch = require('fast-json-patch');
 
-const continuityServiceType = 'Continuity2017Peer';
-
 const ldDocuments = new Map();
 const ledgerNode = helpers.createMockLedgerNode({ldDocuments});
 
@@ -21,7 +19,6 @@ const mockData = require('./mock.data');
 
 let maintainerDidDocumentFull;
 let witnessDidDocumentFull;
-let witnessServiceId;
 describe('validate API ValidatorParameterSet', () => {
   describe('operationValidator', () => {
     beforeEach(async () => {
@@ -30,7 +27,6 @@ describe('validate API ValidatorParameterSet', () => {
       ldDocuments.set(maintainerDidDocument.id, maintainerDidDocument);
       witnessDidDocumentFull = await v1.generate();
       const {didDocument: witnessDidDocument} = witnessDidDocumentFull;
-      witnessServiceId = `${witnessDidDocument.id}#MyServiceName`;
       ldDocuments.set(witnessDidDocument.id, witnessDidDocument);
     });
     describe('create ValidatorParameterSet operation', () => {

--- a/test/mocha/17-validate-validator-parameter-set.js
+++ b/test/mocha/17-validate-validator-parameter-set.js
@@ -89,7 +89,7 @@ describe('validate API ValidatorParameterSet', () => {
       it('rejects op with doc ID that does not match the config', async () => {
         const validatorParameterSetDoc = _generateValidatorParameterSetDoc();
         validatorParameterSetDoc.id =
-          'did:v1:uuid:4da302e3-0fe0-49c6-a7c3-55ff4e1ef5fa';
+          'did:v1:test:uuid:4da302e3-0fe0-49c6-a7c3-55ff4e1ef5fa';
         let operation = await _wrap(
           {didDocument: validatorParameterSetDoc, operationType: 'create'});
         const key = _getMaintainerKeys();
@@ -422,7 +422,7 @@ describe('validate API ValidatorParameterSet', () => {
 
         // attempt to change document id
         validatorParameterSetDoc.type =
-          'did:v1:uuid:f6648d4e-6e4c-4c35-b7b4-2e045f207c2d';
+          'did:v1:test:uuid:f6648d4e-6e4c-4c35-b7b4-2e045f207c2d';
 
         const patch = jsonpatch.generate(observer);
 

--- a/test/mocha/17-validate-validator-parameter-set.js
+++ b/test/mocha/17-validate-validator-parameter-set.js
@@ -20,23 +20,18 @@ const ledgerNode = helpers.createMockLedgerNode({ldDocuments});
 const mockData = require('./mock.data');
 
 let maintainerDidDocumentFull;
-let electorDidDocumentFull;
-let electorServiceId;
+let witnessDidDocumentFull;
+let witnessServiceId;
 describe('validate API ValidatorParameterSet', () => {
   describe('operationValidator', () => {
     beforeEach(async () => {
       maintainerDidDocumentFull = await v1.generate();
       const {didDocument: maintainerDidDocument} = maintainerDidDocumentFull;
       ldDocuments.set(maintainerDidDocument.id, maintainerDidDocument);
-      electorDidDocumentFull = await v1.generate();
-      const {didDocument: electorDidDocument} = electorDidDocumentFull;
-      electorServiceId = `${electorDidDocument.id}#MyServiceName`;
-      electorDidDocument.service = [{
-        id: electorServiceId,
-        type: continuityServiceType,
-        serviceEndpoint: mockData.electorEndpoint[0],
-      }];
-      ldDocuments.set(electorDidDocument.id, electorDidDocument);
+      witnessDidDocumentFull = await v1.generate();
+      const {didDocument: witnessDidDocument} = witnessDidDocumentFull;
+      witnessServiceId = `${witnessDidDocument.id}#MyServiceName`;
+      ldDocuments.set(witnessDidDocument.id, witnessDidDocument);
     });
     describe('create ValidatorParameterSet operation', () => {
       it('validates op with proper proof', async () => {
@@ -196,13 +191,13 @@ describe('validate API ValidatorParameterSet', () => {
         should.exist(result.error.details.baseUrl);
         should.exist(result.error.details.allowedServiceBaseUrl);
       });
-    }); // end create electorPool operation
+    }); // end create witnessPool operation
 
     describe('update ValidatorParameterSet operation', () => {
       it('validates an operation with proper proof', async () => {
         const validatorParameterSetDoc = _generateValidatorParameterSetDoc();
         // the invocationTarget is the ledger ID
-        // electorPoolDoc.electorPool[0].capability[0].invocationTarget =
+        // witnessPoolDoc.witnessPool[0].capability[0].invocationTarget =
         //   'urn:uuid:e9e63a07-15b1-4e8f-b725-a71a362cfd99';
         ldDocuments.set(
           validatorParameterSetDoc.id, clone(validatorParameterSetDoc));
@@ -212,7 +207,10 @@ describe('validate API ValidatorParameterSet', () => {
         const patch = jsonpatch.generate(observer);
 
         let operation = {
-          '@context': constants.WEB_LEDGER_CONTEXT_V1_URL,
+          '@context': [
+            constants.WEB_LEDGER_CONTEXT_V1_URL,
+            constants.ZCAP_CONTEXT_V1_URL
+          ],
           creator: 'https://example.com/some/ledger/node',
           recordPatch: {
             '@context': mockData.patchContext,
@@ -246,7 +244,7 @@ describe('validate API ValidatorParameterSet', () => {
         //   key,
         // });
         const ledgerConfig = clone(mockData.ledgerConfigurations.alpha);
-        ledgerConfig.electorSelectionMethod = {
+        ledgerConfig.witnessSelectionMethod = {
           type: 'VeresOne',
         };
         let err;
@@ -270,7 +268,7 @@ describe('validate API ValidatorParameterSet', () => {
       it('rejects an operation removing allowedServiceBaseUrl', async () => {
         const validatorParameterSetDoc = _generateValidatorParameterSetDoc();
         // the invocationTarget is the ledger ID
-        // electorPoolDoc.electorPool[0].capability[0].invocationTarget =
+        // witnessPoolDoc.witnessPool[0].capability[0].invocationTarget =
         //   'urn:uuid:e9e63a07-15b1-4e8f-b725-a71a362cfd99';
         ldDocuments.set(
           validatorParameterSetDoc.id, clone(validatorParameterSetDoc));
@@ -281,7 +279,10 @@ describe('validate API ValidatorParameterSet', () => {
         const patch = jsonpatch.generate(observer);
 
         let operation = {
-          '@context': constants.WEB_LEDGER_CONTEXT_V1_URL,
+          '@context': [
+            constants.WEB_LEDGER_CONTEXT_V1_URL,
+            constants.ZCAP_CONTEXT_V1_URL
+          ],
           creator: 'https://example.com/some/ledger/node',
           recordPatch: {
             '@context': mockData.patchContext,
@@ -315,7 +316,7 @@ describe('validate API ValidatorParameterSet', () => {
         //   key,
         // });
         const ledgerConfig = clone(mockData.ledgerConfigurations.alpha);
-        ledgerConfig.electorSelectionMethod = {
+        ledgerConfig.witnessSelectionMethod = {
           type: 'VeresOne',
         };
         let err;
@@ -342,7 +343,7 @@ describe('validate API ValidatorParameterSet', () => {
       it('rejects an operation that attempts to change doc type', async () => {
         const validatorParameterSetDoc = _generateValidatorParameterSetDoc();
         // the invocationTarget is the ledger ID
-        // electorPoolDoc.electorPool[0].capability[0].invocationTarget =
+        // witnessPoolDoc.witnessPool[0].capability[0].invocationTarget =
         //   'urn:uuid:e9e63a07-15b1-4e8f-b725-a71a362cfd99';
         ldDocuments.set(
           validatorParameterSetDoc.id, clone(validatorParameterSetDoc));
@@ -354,7 +355,10 @@ describe('validate API ValidatorParameterSet', () => {
         const patch = jsonpatch.generate(observer);
 
         let operation = {
-          '@context': constants.WEB_LEDGER_CONTEXT_V1_URL,
+          '@context': [
+            constants.WEB_LEDGER_CONTEXT_V1_URL,
+            constants.ZCAP_CONTEXT_V1_URL
+          ],
           creator: 'https://example.com/some/ledger/node',
           recordPatch: {
             '@context': mockData.patchContext,
@@ -388,7 +392,7 @@ describe('validate API ValidatorParameterSet', () => {
         //   key,
         // });
         const ledgerConfig = clone(mockData.ledgerConfigurations.alpha);
-        ledgerConfig.electorSelectionMethod = {
+        ledgerConfig.witnessSelectionMethod = {
           type: 'VeresOne',
         };
         let err;
@@ -414,7 +418,7 @@ describe('validate API ValidatorParameterSet', () => {
       it('rejects an operation that attempts to change doc ID', async () => {
         const validatorParameterSetDoc = _generateValidatorParameterSetDoc();
         // the invocationTarget is the ledger ID
-        // electorPoolDoc.electorPool[0].capability[0].invocationTarget =
+        // witnessPoolDoc.witnessPool[0].capability[0].invocationTarget =
         //   'urn:uuid:e9e63a07-15b1-4e8f-b725-a71a362cfd99';
         ldDocuments.set(
           validatorParameterSetDoc.id, clone(validatorParameterSetDoc));
@@ -427,7 +431,10 @@ describe('validate API ValidatorParameterSet', () => {
         const patch = jsonpatch.generate(observer);
 
         let operation = {
-          '@context': constants.WEB_LEDGER_CONTEXT_V1_URL,
+          '@context': [
+            constants.WEB_LEDGER_CONTEXT_V1_URL,
+            constants.ZCAP_CONTEXT_V1_URL
+          ],
           creator: 'https://example.com/some/ledger/node',
           recordPatch: {
             '@context': mockData.patchContext,
@@ -460,7 +467,7 @@ describe('validate API ValidatorParameterSet', () => {
         //   key,
         // });
         const ledgerConfig = clone(mockData.ledgerConfigurations.alpha);
-        ledgerConfig.electorSelectionMethod = {
+        ledgerConfig.witnessSelectionMethod = {
           type: 'VeresOne',
         };
         let err;
@@ -483,7 +490,7 @@ describe('validate API ValidatorParameterSet', () => {
         result.error.name.should.equal('ValidationError');
         result.error.message.should.contain('immutable');
       });
-    }); // end update electorPool operation
+    }); // end update witnessPool operation
   });
 });
 
@@ -504,7 +511,12 @@ function _getMaintainerKeys() {
 // this is a modified version of the wrap API found in did-veres-one and
 // web-ledger-client
 async function _wrap({didDocument, operationType = 'create'}) {
-  const operation = {'@context': constants.WEB_LEDGER_CONTEXT_V1_URL};
+  const operation = {
+    '@context': [
+      constants.WEB_LEDGER_CONTEXT_V1_URL,
+      constants.ZCAP_CONTEXT_V1_URL
+    ]
+  };
 
   // normally this is set basted on the targetNode value provided by the
   // ledger-agent HTTP API

--- a/test/mocha/mock.data.js
+++ b/test/mocha/mock.data.js
@@ -46,7 +46,8 @@ mock.proof = {
   created: '2021-01-10T23:10:25Z',
   capability: 'did:v1:test:uuid:c37e914a-1e2a-4d59-9668-ee93458fd19a',
   capabilityAction: 'write',
-  invocationTarget: 'did:v1:test:nym:z6MkgUj',
+  invocationTarget:
+    'did:v1:nym:z6Mkogv718iDZqyoTmPKagKcG2VBXXz6w4xau8fL5jjB948r',
   proofPurpose: 'capabilityInvocation',
   proofValue: 'z3t9it5yhFHkqWnHKMQ2DWVj7aHDN37f95UzhQYQGYd9LyTSGzufCiTwDWN' +
     'fCdxQA9ZHcTTVAhHwoAji2AJnk2E6',

--- a/test/mocha/mock.data.js
+++ b/test/mocha/mock.data.js
@@ -44,19 +44,20 @@ const validatorParameterSet = mock.validatorParameterSet = {};
 mock.proof = {
   type: 'Ed25519Signature2020',
   created: '2021-01-10T23:10:25Z',
-  capability: 'did:v1:uuid:c37e914a-1e2a-4d59-9668-ee93458fd19a',
+  capability: 'did:v1:test:uuid:c37e914a-1e2a-4d59-9668-ee93458fd19a',
   capabilityAction: 'write',
-  invocationTarget: 'did:v1:nym:ledger',
+  invocationTarget: 'did:v1:test:nym:z6MkgUj',
   proofPurpose: 'capabilityInvocation',
   proofValue: 'z3t9it5yhFHkqWnHKMQ2DWVj7aHDN37f95UzhQYQGYd9LyTSGzufCiTwDWN' +
     'fCdxQA9ZHcTTVAhHwoAji2AJnk2E6',
-  verificationMethod: 'did:v1:nym:z279yHL6HsxRzCPU78DAWgZVieb8xPK1mJKJBb' +
+  verificationMethod: 'did:v1:test:nym:z279yHL6HsxRzCPU78DAWgZVieb8xPK1mJKJBb' +
     'P8T2CezuFY#z279tKmToKKMjQ8tsCgTbBBthw5xEzHWL6GCqZyQnzZr7wUo'
 };
 
 // need to return document for beta but *not* for alpha
-const didAlpha = 'did:v1:uuid:40aea416-73b2-436f-bb91-41175494d72b';
-const didBeta = 'did:v1:nym:z6MkwCGzK8WaRM6mfshwpZhJLQpUZD5ePj4PFetLMYa2NCAg';
+const didAlpha = 'did:v1:test:uuid:40aea416-73b2-436f-bb91-41175494d72b';
+const didBeta = 'did:v1:test:nym:z6MkwCGzK8WaRM6mfshwpZhJLQpUZD5ePj' +
+  '4PFetLMYa2NCAg';
 const terribleDids = new Set([didAlpha, didBeta]);
 
 mock.ledgerNode = {
@@ -106,14 +107,14 @@ electorPoolDocument.alpha = {
     constants.WEB_LEDGER_CONTEXT_V1_URL,
     constants.ED25519_2020_CONTEXT_V1_URL,
   ],
-  id: 'did:v1:uuid:b3275fed-daf4-4c07-b63a-747fa8857609',
+  id: 'did:v1:test:uuid:b3275fed-daf4-4c07-b63a-747fa8857609',
   type: 'ElectorPool',
   // FIXME: this has to be in the v1 context before we can sign documents
   // veresOneTicketRate: 10, /* TBD */
   controller: '', // replaced with maintainer's DID in test
   electorPool: [{
     id: 'urn:uuid:89a62413-0ada-461b-b672-1b28afefaca8',
-    elector: 'did:v1:nym:50f28192-8f52-4bf2-a9b1-d203f6611456',
+    elector: 'did:v1:test:nym:50f28192-8f52-4bf2-a9b1-d203f6611456',
     service: 'urn:uuid:50f28192-8f52-4bf2-a9b1-d203f6611456',
     type: ['Continuity2017GuarantorElector', 'Continuity2017Elector'],
     // other restrictions/capabilities like guarantor, recovery,
@@ -131,23 +132,23 @@ electorPoolDocument.alpha = {
 /* eslint-disable quotes, quote-props, max-len */
 privateDidDocuments.alpha = {
   "@context": didContexts,
-  id: 'did:v1:nym:z6MkvTVoxyV4SLdSRxFBY2zgaCgRRU8EpzjxJrRPeKzUrq9w',
+  id: 'did:v1:test:nym:z6MkvTVoxyV4SLdSRxFBY2zgaCgRRU8EpzjxJrRPeKzUrq9w',
   authentication: [{
-    id: 'did:v1:nym:z6MkvTVoxyV4SLdSRxFBY2zgaCgRRU8EpzjxJrRPeKzUrq9w#z6MkvTVoxyV4SLdSRxFBY2zgaCgRRU8EpzjxJrRPeKzUrq9w',
+    id: 'did:v1:test:nym:z6MkvTVoxyV4SLdSRxFBY2zgaCgRRU8EpzjxJrRPeKzUrq9w#z6MkvTVoxyV4SLdSRxFBY2zgaCgRRU8EpzjxJrRPeKzUrq9w',
     type: 'Ed25519VerificationKey2020',
-    controller: 'did:v1:nym:z6MkvTVoxyV4SLdSRxFBY2zgaCgRRU8EpzjxJrRPeKzUrq9w',
+    controller: 'did:v1:test:nym:z6MkvTVoxyV4SLdSRxFBY2zgaCgRRU8EpzjxJrRPeKzUrq9w',
     publicKeyMultibase: 'z6MkvTVoxyV4SLdSRxFBY2zgaCgRRU8EpzjxJrRPeKzUrq9w'
   }],
   "capabilityDelegation": [{
-    id: 'did:v1:nym:z6MkvTVoxyV4SLdSRxFBY2zgaCgRRU8EpzjxJrRPeKzUrq9w#z6MkwHphHeS9GM6hDFnM2bnfu1Ekf9fz8gBcs5cviTDhuV2F',
+    id: 'did:v1:test:nym:z6MkvTVoxyV4SLdSRxFBY2zgaCgRRU8EpzjxJrRPeKzUrq9w#z6MkwHphHeS9GM6hDFnM2bnfu1Ekf9fz8gBcs5cviTDhuV2F',
     type: 'Ed25519VerificationKey2020',
-    controller: 'did:v1:nym:z6MkwHphHeS9GM6hDFnM2bnfu1Ekf9fz8gBcs5cviTDhuV2F',
+    controller: 'did:v1:test:nym:z6MkwHphHeS9GM6hDFnM2bnfu1Ekf9fz8gBcs5cviTDhuV2F',
     publicKeyMultibase: 'z6MkwHphHeS9GM6hDFnM2bnfu1Ekf9fz8gBcs5cviTDhuV2F'
   }],
   "capabilityInvocation": [{
-    id: 'did:v1:nym:z6MkvTVoxyV4SLdSRxFBY2zgaCgRRU8EpzjxJrRPeKzUrq9w#z6MkmzCb5xJTgWjATFq8q9y8rXJNyYFT6Eeaxeb3eY4Kv1iy',
+    id: 'did:v1:test:nym:z6MkvTVoxyV4SLdSRxFBY2zgaCgRRU8EpzjxJrRPeKzUrq9w#z6MkmzCb5xJTgWjATFq8q9y8rXJNyYFT6Eeaxeb3eY4Kv1iy',
     type: 'Ed25519VerificationKey2020',
-    controller: 'did:v1:nym:z6MkmzCb5xJTgWjATFq8q9y8rXJNyYFT6Eeaxeb3eY4Kv1iy',
+    controller: 'did:v1:test:nym:z6MkmzCb5xJTgWjATFq8q9y8rXJNyYFT6Eeaxeb3eY4Kv1iy',
     publicKeyMultibase: 'z6MkmzCb5xJTgWjATFq8q9y8rXJNyYFT6Eeaxeb3eY4Kv1iy'
   }]
 };
@@ -155,15 +156,15 @@ privateDidDocuments.alpha = {
 privateDidDocuments.beta = {
   // FIXME: use constant and cached version when available
   "@context": [constants.DID_CONTEXT_URL, constants.VERES_ONE_CONTEXT_V1_URL],
-  "id": "did:v1:nym:z279nCCZVzxreYfLw3EtFLtBMSVVY2pA6uxKengriMCdG3DF",
+  "id": "did:v1:test:nym:z279nCCZVzxreYfLw3EtFLtBMSVVY2pA6uxKengriMCdG3DF",
   "authentication": [
     {
       "type": "Ed25519SignatureAuthentication2018",
       "publicKey": [
         {
-          "id": "did:v1:nym:z279nCCZVzxreYfLw3EtFLtBMSVVY2pA6uxKengriMCdG3DF#authn-key-1",
+          "id": "did:v1:test:nym:z279nCCZVzxreYfLw3EtFLtBMSVVY2pA6uxKengriMCdG3DF#authn-key-1",
           "type": "Ed25519VerificationKey201X",
-          "controller": "did:v1:nym:z279nCCZVzxreYfLw3EtFLtBMSVVY2pA6uxKengriMCdG3DF",
+          "controller": "did:v1:test:nym:z279nCCZVzxreYfLw3EtFLtBMSVVY2pA6uxKengriMCdG3DF",
           "publicKeyBase58": "7tJdgUebDRaVFR2d8LzV9BK7RMz5aw2AuW5LsEBBAKWs",
           "privateKey": {
             "privateKeyBase58": "4kftxewt3RQUW7k1MoTqEbZW5MnsJszNAwgEqbjJvKmJYeyUJFmkzYwwMZfB7Z5bWFyo1pQJzZL2mLL5zagc3dAT"
@@ -177,9 +178,9 @@ privateDidDocuments.beta = {
       "type": "Ed25519SignatureCapabilityAuthorization2018",
       "publicKey": [
         {
-          "id": "did:v1:nym:z279nCCZVzxreYfLw3EtFLtBMSVVY2pA6uxKengriMCdG3DF#ocap-delegate-key-1",
+          "id": "did:v1:test:nym:z279nCCZVzxreYfLw3EtFLtBMSVVY2pA6uxKengriMCdG3DF#ocap-delegate-key-1",
           "type": "Ed25519VerificationKey2018",
-          "controller": "did:v1:nym:z279nCCZVzxreYfLw3EtFLtBMSVVY2pA6uxKengriMCdG3DF",
+          "controller": "did:v1:test:nym:z279nCCZVzxreYfLw3EtFLtBMSVVY2pA6uxKengriMCdG3DF",
           "publicKeyBase58": "CWERGaLLTsWGAKzpTKpHs9WyZ5Xczgj8HSbcZ7FjGAtQ",
           "privateKey": {
             "privateKeyBase58": "4bzwvphLSbKF3zWEB18dEFusRPSvpFqefeGqUSfNr3dwcN6KD7xNbAG1q1nBAFu7r6Knj4Lmex1zvWXrv632eS4Q"
@@ -193,9 +194,9 @@ privateDidDocuments.beta = {
       "type": "Ed25519SignatureCapabilityAuthorization2018",
       "publicKey": [
         {
-          "id": "did:v1:nym:z279nCCZVzxreYfLw3EtFLtBMSVVY2pA6uxKengriMCdG3DF#ocap-invoke-key-1",
+          "id": "did:v1:test:nym:z279nCCZVzxreYfLw3EtFLtBMSVVY2pA6uxKengriMCdG3DF#ocap-invoke-key-1",
           "type": "Ed25519VerificationKey2018",
-          "controller": "did:v1:nym:z279nCCZVzxreYfLw3EtFLtBMSVVY2pA6uxKengriMCdG3DF",
+          "controller": "did:v1:test:nym:z279nCCZVzxreYfLw3EtFLtBMSVVY2pA6uxKengriMCdG3DF",
           "publicKeyBase58": "5U6TbzeAqQtSq9N52XPHFrF5cWwDPHk96uJvKshP4jN5",
           "privateKey": {
             "privateKeyBase58": "5hvHHCpocudyac6fT6jJCHe2WThQHsKYsjazkGV2L1Umwj5w9HtzcqoZ886yHJdHKbpC4W2qGhUMPbHNPpNDK6Dj"
@@ -212,7 +213,7 @@ didDocuments.alpha = privateDidDocuments.alpha;
 // didDocuments.beta = _stripPrivateKeys(privateDidDocuments.beta);
 
 mock.VALIDATOR_PARAMETER_SET =
-  'did:v1:uuid:b2f1d301-fddd-4743-b666-b7ec8f08c310';
+  'did:v1:test:uuid:b2f1d301-fddd-4743-b666-b7ec8f08c310';
 validatorParameterSet.alpha = {
   '@context': didContexts,
   id: mock.VALIDATOR_PARAMETER_SET,
@@ -237,7 +238,7 @@ ledgerConfigurations.alpha = {
   consensusMethod: 'Continuity2017',
   electorSelectionMethod: {
     type: 'ElectorPoolElectorSelection',
-    electorPool: 'did:v1:uuid:acc4c5af-7445-4046-a39c-10653a0c7ac0'
+    electorPool: 'did:v1:test:uuid:acc4c5af-7445-4046-a39c-10653a0c7ac0'
   },
   operationValidator: [{
     type: 'VeresOneValidator2017',
@@ -334,7 +335,7 @@ operations.updateInvalidChange = {
 };
 
 capabilities.authorizeRequest =
-  'did:v1:uuid:652de430-1d6f-11e8-878c-2bfa41196bf6';
+  'did:v1:test:uuid:652de430-1d6f-11e8-878c-2bfa41196bf6';
 
 /*
 

--- a/test/mocha/mock.data.js
+++ b/test/mocha/mock.data.js
@@ -19,7 +19,7 @@ const didContexts = [
 mock.existingDids = {};
 const capabilities = mock.capabilities = {};
 const didDocuments = mock.didDocuments = {};
-const electorPoolDocument = mock.electorPoolDocument = {};
+const witnessPoolDocument = mock.witnessPoolDocument = {};
 // eslint-disable-next-line no-unused-vars
 const ldDocuments = mock.ldDocuments = {};
 const ledgerConfigurations = mock.ledgerConfigurations = {};
@@ -93,41 +93,28 @@ mock.ledgerNode = {
   }
 };
 
-const electorEndpoint = mock.electorEndpoint = [];
+const witnessEndpoint = mock.witnessEndpoint = [];
 
 // NOTE: actual endpoints terminate with a base58 encoded public key
 for(let i = 0; i < 10; ++i) {
-  electorEndpoint.push('https://example.com/consensus/continuity2017/voters/' +
+  witnessEndpoint.push('https://example.com/consensus/continuity2017/voters/' +
     uuid());
 }
 
-electorPoolDocument.alpha = {
+witnessPoolDocument.alpha = {
   '@context': [
     constants.DID_CONTEXT_URL,
     constants.VERES_ONE_CONTEXT_V1_URL,
     constants.WEB_LEDGER_CONTEXT_V1_URL,
-    constants.ED25519_2020_CONTEXT_V1_URL,
+    constants.ED25519_2020_CONTEXT_V1_URL
   ],
-  id: 'did:v1:test:uuid:b3275fed-daf4-4c07-b63a-747fa8857609',
-  type: 'ElectorPool',
-  // FIXME: this has to be in the v1 context before we can sign documents
-  // veresOneTicketRate: 10, /* TBD */
-  controller: '', // replaced with maintainer's DID in test
-  electorPool: [{
-    id: 'urn:uuid:89a62413-0ada-461b-b672-1b28afefaca8',
-    elector: 'did:v1:test:nym:50f28192-8f52-4bf2-a9b1-d203f6611456',
-    service: 'urn:uuid:50f28192-8f52-4bf2-a9b1-d203f6611456',
-    type: ['Continuity2017GuarantorElector', 'Continuity2017Elector'],
-    // other restrictions/capabilities like guarantor, recovery,
-    // or ocap w/ticket caveat
-    capability: [{
-      id: '', // replaced with DID in test
-      caveat: [{
-        type: 'VeresOneElectorTicketAgent' /* TBD */
-      }]
-    }]
-  }],
-  maximumElectorCount: 10,
+  id: 'did:v1:uuid:2f3c9466-ddc9-11eb-92f2-f31707920b3b',
+  type: 'WitnessPool',
+  // the rest of these fields are test-run specific and set at runtime
+  controller: '',
+  maximumWitnessCount: 0,
+  primaryWitnessCandidate: [],
+  secondaryWitnessCandidate: []
 };
 
 /* eslint-disable quotes, quote-props, max-len */
@@ -237,9 +224,9 @@ ledgerConfigurations.alpha = {
   type: 'WebLedgerConfiguration',
   ledger: 'did:v1:c02915fc-672d-4568-8e6e-b12a0b35cbb3',
   consensusMethod: 'Continuity2017',
-  electorSelectionMethod: {
-    type: 'ElectorPoolElectorSelection',
-    electorPool: 'did:v1:test:uuid:acc4c5af-7445-4046-a39c-10653a0c7ac0'
+  witnessSelectionMethod: {
+    type: 'WitnessPoolWitnessSelection',
+    witnessPool: 'did:v1:uuid:2f3c9466-ddc9-11eb-92f2-f31707920b3b'
   },
   operationValidator: [{
     type: 'VeresOneValidator2017',
@@ -251,24 +238,15 @@ ledgerConfigurations.alpha = {
   }],
   ledgerConfigurationValidator: [{
     type: 'VeresOneValidator2017',
-  }, /*{
-    // FIXME: enable signature validation on configuration as well.  How
-    // are keys dereferenced?
-    type: 'SignatureValidator2017',
-    validatorFilter: [{
-      type: 'ValidatorFilterByType',
-      validatorFilterByType: ['WebLedgerConfiguration']
-    }],
-    approvedSigner: [
-      'did:v1:53ebca61-5687-4558-b90a-03167e4c2838'
-    ],
-    minimumSignaturesRequired: 1
-  }*/],
+  }],
   sequence: 0,
 };
 
 operations.create = {
-  '@context': constants.WEB_LEDGER_CONTEXT_V1_URL,
+  '@context': [
+    constants.WEB_LEDGER_CONTEXT_V1_URL,
+    constants.ZCAP_CONTEXT_V1_URL
+  ],
   type: 'CreateWebLedgerRecord',
   record: didDocuments.alpha,
   // this is the `targetNode` of the ledgerAgent
@@ -276,14 +254,20 @@ operations.create = {
     'continuity2017/voters/z6MkhoJ1djxR53kw5fQqRTZ34cGwAdSPvksZR2Xm7u1Y4TfE'
 };
 
-operations.createElectorPool = {
-  '@context': constants.WEB_LEDGER_CONTEXT_V1_URL,
+operations.createWitnessPool = {
+  '@context': [
+    constants.WEB_LEDGER_CONTEXT_V1_URL,
+    constants.ZCAP_CONTEXT_V1_URL
+  ],
   type: 'CreateWebLedgerRecord',
   record: didDocuments.alpha
 };
 
 operations.update = {
-  '@context': constants.WEB_LEDGER_CONTEXT_V1_URL,
+  '@context': [
+    constants.WEB_LEDGER_CONTEXT_V1_URL,
+    constants.ZCAP_CONTEXT_V1_URL
+  ],
   type: 'UpdateWebLedgerRecord',
   recordPatch: {
     '@context': [
@@ -304,7 +288,10 @@ operations.update = {
 };
 
 operations.updateInvalidPatch = {
-  '@context': constants.WEB_LEDGER_CONTEXT_V1_URL,
+  '@context': [
+    constants.WEB_LEDGER_CONTEXT_V1_URL,
+    constants.ZCAP_CONTEXT_V1_URL
+  ],
   type: 'UpdateWebLedgerRecord',
   recordPatch: {
     // FIXME: use constant and cached version when available
@@ -319,7 +306,10 @@ operations.updateInvalidPatch = {
 };
 
 operations.updateInvalidChange = {
-  '@context': constants.WEB_LEDGER_CONTEXT_V1_URL,
+  '@context': [
+    constants.WEB_LEDGER_CONTEXT_V1_URL,
+    constants.ZCAP_CONTEXT_V1_URL
+  ],
   type: 'UpdateWebLedgerRecord',
   recordPatch: {
     // FIXME: use constant and cached version when available

--- a/test/package.json
+++ b/test/package.json
@@ -17,7 +17,7 @@
     "bedrock-injector": "^1.0.0",
     "bedrock-jobs": "^3.0.0",
     "bedrock-jsonld-document-loader": "^1.0.0",
-    "bedrock-ledger-context": "^19.0.0",
+    "bedrock-ledger-context": "20.0.1",
     "bedrock-ledger-node": "^12.0.0",
     "bedrock-ledger-storage-mongodb": "^5.1.0",
     "bedrock-ledger-utils": "^1.0.0",

--- a/test/package.json
+++ b/test/package.json
@@ -19,7 +19,7 @@
     "bedrock-jsonld-document-loader": "^1.0.0",
     "bedrock-ledger-context": "^18.1.0",
     "bedrock-ledger-node": "^12.0.0",
-    "bedrock-ledger-storage-mongodb": "digitalbazaar/bedrock-ledger-storage-mongodb#update-idx",
+    "bedrock-ledger-storage-mongodb": "^5.1.0",
     "bedrock-ledger-utils": "^1.0.0",
     "bedrock-mongodb": "^8.1.0",
     "bedrock-permission": "^3.0.0",

--- a/test/package.json
+++ b/test/package.json
@@ -17,7 +17,7 @@
     "bedrock-injector": "^1.0.0",
     "bedrock-jobs": "^3.0.0",
     "bedrock-jsonld-document-loader": "^1.0.0",
-    "bedrock-ledger-context": "^18.1.0",
+    "bedrock-ledger-context": "^19.0.0",
     "bedrock-ledger-node": "^12.0.0",
     "bedrock-ledger-storage-mongodb": "^5.1.0",
     "bedrock-ledger-utils": "^1.0.0",

--- a/test/test.config.js
+++ b/test/test.config.js
@@ -12,5 +12,5 @@ config['https-agent'].rejectUnauthorized = false;
 
 const cfg = config['veres-one-validator'];
 
-// Set mode to 'dev', so that DIDs are created as 'did:v1:...' in tests
-cfg.environment = 'dev';
+// Set mode to 'test', so that DIDs are created as 'did:v1:test:...' in tests
+cfg.environment = 'test';


### PR DESCRIPTION
THIS IS NOT COMPLETE.
This is a start on updating validators to support witness selection.

p.s. this assumes that veres-one should be running in test mode when testing i.e. validators should expect the prefix `did:v1:test:nym` and not `did:v1:nym`.