### PR TITLE
Update validators for dynamic root zcaps

### DIFF
--- a/lib/validators/helpers.js
+++ b/lib/validators/helpers.js
@@ -14,6 +14,8 @@ const v1 = require('did-veres-one').driver();
 const api = {};
 module.exports = api;
 
+const ZCAP_ROOT_PREFIX = 'urn:zcap:root:';
+
 // delimiters for a DID URL
 const splitRegex = /[;|\/|\?|#]/;
 // all the keys extracted using the document loader are restricted by the
@@ -259,3 +261,16 @@ async function _pluckDidNode(did, target, didDocument) {
   err.status = 404;
   throw err;
 }
+
+/**
+ * Takes in the expected targets, appends a root prefix and URI encodes
+ *   the expected target.
+ *
+ * @param {object} options - Options to use.
+ * @param {string} options.expectedTarget - The expectedTarget for
+ *   the operation.
+ *
+ * @returns {string} Returns an expectedRootCapability id.
+ */
+api.getExpectedRootCapability = ({expectedTarget}) =>
+  `${ZCAP_ROOT_PREFIX}${encodeURIComponent(expectedTarget)}`;

--- a/lib/validators/proofs.js
+++ b/lib/validators/proofs.js
@@ -53,7 +53,9 @@ module.exports = async ({basisBlockHeight, ledgerNode, validatorInput}) => {
     purpose: new CapabilityInvocation({
       expectedAction: capabilityAction,
       // controller: record,
-      expectedTarget
+      expectedTarget,
+      expectedRootCapability: helpers.getExpectedRootCapability(
+        {expectedTarget})
     }),
     suite: new Ed25519Signature2020(),
   });

--- a/lib/validators/webLedgerConfiguration.js
+++ b/lib/validators/webLedgerConfiguration.js
@@ -44,7 +44,6 @@ module.exports = async ({ledgerNode, validatorInput}) => {
       }, e);
     return {valid: false, error};
   }
-
   const controller = {
     '@context': constants.SECURITY_CONTEXT_URL,
     id: publicKeyId,
@@ -79,7 +78,7 @@ function _getPublicKey(publicKeyId) {
   return {
     id: publicKeyId,
     type: 'Ed25519VerificationKey2020',
-    controller: publicKeyId,
+    controller: publicKeyId.split('#')[0],
     publicKeyMultibase
   };
 }

--- a/lib/validators/webLedgerConfiguration.js
+++ b/lib/validators/webLedgerConfiguration.js
@@ -27,7 +27,7 @@ module.exports = async ({ledgerNode, validatorInput}) => {
     return result;
   }
   // FIXME: for testnet_v2, the genesis configuration has a
-  // AssertionProofPurpose
+  // CapabilityInvocation purpose
   const {proof: {verificationMethod: publicKeyId}} = validatorInput;
 
   let computedKey;

--- a/lib/validators/webLedgerConfiguration.js
+++ b/lib/validators/webLedgerConfiguration.js
@@ -47,7 +47,7 @@ module.exports = async ({ledgerNode, validatorInput}) => {
   const controller = {
     '@context': constants.SECURITY_CONTEXT_URL,
     id: publicKeyId,
-    assertionMethod: publicKeyId,
+    capabilityInvocation: publicKeyId,
   };
   const proofVerifyResult = await jsigs.verify(validatorInput, {
     documentLoader,

--- a/lib/validators/webLedgerConfiguration.js
+++ b/lib/validators/webLedgerConfiguration.js
@@ -7,12 +7,13 @@ const bedrock = require('bedrock');
 const {config: {constants}, util: {BedrockError}} = bedrock;
 const {documentLoader} = require('bedrock-jsonld-document-loader');
 const jsigs = require('jsonld-signatures');
+const helpers = require('./helpers');
 const {validate} = require('bedrock-validation');
 const {Ed25519Signature2020} =
   require('@digitalbazaar/ed25519-signature-2020');
 const {Ed25519VerificationKey2020} =
   require('@digitalbazaar/ed25519-verification-key-2020');
-const {AssertionProofPurpose} = jsigs.purposes;
+const {CapabilityInvocation} = require('@digitalbazaar/zcapld');
 const URL = require('url');
 
 /* eslint-disable-next-line no-unused-vars */
@@ -51,7 +52,13 @@ module.exports = async ({ledgerNode, validatorInput}) => {
   };
   const proofVerifyResult = await jsigs.verify(validatorInput, {
     documentLoader,
-    purpose: new AssertionProofPurpose({controller}),
+    purpose: new CapabilityInvocation({
+      expectedAction: 'write',
+      controller,
+      expectedTarget: validatorInput.ledger,
+      expectedRootCapability: helpers.getExpectedRootCapability(
+        {expectedTarget: validatorInput.ledger})
+    }),
     suite: new Ed25519Signature2020({key}),
   });
   if(!proofVerifyResult.verified) {

--- a/schemas/veres-one-validator.js
+++ b/schemas/veres-one-validator.js
@@ -488,6 +488,7 @@ const ledgerConfiguration = {
   properties: {
     '@context': schemas.jsonldContext([
       constants.WEB_LEDGER_CONTEXT_V1_URL,
+      constants.ZCAP_CONTEXT_V1_URL,
       constants.ED25519_2020_CONTEXT_V1_URL
     ]),
     consensusMethod: {const: 'Continuity2017'},
@@ -537,7 +538,7 @@ const ledgerConfiguration = {
           properties: {
             proofPurpose: {
               type: 'string',
-              enum: ['assertionMethod']
+              enum: ['capabilityInvocation']
             }
           }
         }

--- a/test/mocha/05-validate-async.js
+++ b/test/mocha/05-validate-async.js
@@ -21,7 +21,7 @@ const v1 = require('did-veres-one').driver({mode: 'test'});
 
 const {util: {clone}} = bedrock;
 
-describe.only('validate regular DIDs', () => {
+describe('validate regular DIDs', () => {
   describe('validate API', () => {
     it('throws on missing ledgerNode parameter', async () => {
       let result;
@@ -67,7 +67,7 @@ describe.only('validate regular DIDs', () => {
       result.valid.should.be.true;
     });
     it('throws on CreateWebLedgerRecord without basisBlockHeight', async () => {
-      const {did, mockDoc, capabilityInvocationKey} = await _generateDid();
+      const {mockDoc, capabilityInvocationKey} = await _generateDid();
       const mockOperation = clone(mockData.operations.create);
       const capabilityAction = 'write';
       mockOperation.record = mockDoc;
@@ -79,7 +79,7 @@ describe.only('validate regular DIDs', () => {
         documentLoader,
         suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
         purpose: new CapabilityInvocation({
-          capability: did,
+          capability: helpers.generatateRootZcapId({id: mockDoc.id}),
           capabilityAction,
           invocationTarget: mockDoc.id
         })
@@ -117,7 +117,7 @@ describe.only('validate regular DIDs', () => {
         documentLoader,
         suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
         purpose: new CapabilityInvocation({
-          capability: did,
+          capability: helpers.generatateRootZcapId({id: did}),
           capabilityAction,
           invocationTarget: did
         })
@@ -174,7 +174,7 @@ describe.only('validate regular DIDs', () => {
         'capabilityInvocation');
     });
     it('rejects an improper CreateWebLedgerRecord operation', async () => {
-      const {did, mockDoc, capabilityInvocationKey} = await _generateBadDid();
+      const {mockDoc, capabilityInvocationKey} = await _generateBadDid();
       const mockOperation = clone(mockData.operations.create);
       const capabilityAction = 'write';
       mockOperation.record = mockDoc;
@@ -186,7 +186,7 @@ describe.only('validate regular DIDs', () => {
         documentLoader,
         suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
         purpose: new CapabilityInvocation({
-          capability: did,
+          capability: helpers.generatateRootZcapId({id: mockDoc.id}),
           capabilityAction,
           invocationTarget: mockDoc.id
         })
@@ -224,7 +224,7 @@ describe.only('validate regular DIDs', () => {
         documentLoader,
         suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
         purpose: new CapabilityInvocation({
-          capability: did,
+          capability: helpers.generatateRootZcapId({id: mockDoc.id}),
           capabilityAction,
           invocationTarget: mockDoc.id
         })
@@ -282,7 +282,7 @@ describe.only('validate regular DIDs', () => {
           documentLoader,
           suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
           purpose: new CapabilityInvocation({
-            capability: did,
+            capability: helpers.generatateRootZcapId({id: did}),
             capabilityAction,
             invocationTarget: mockOperation.record.id
           })
@@ -321,7 +321,7 @@ describe.only('validate regular DIDs', () => {
           documentLoader,
           suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
           purpose: new CapabilityInvocation({
-            capability: did,
+            capability: helpers.generatateRootZcapId({id: did}),
             capabilityAction,
             invocationTarget: mockOperation.record.id
           })
@@ -374,7 +374,7 @@ describe.only('validate regular DIDs', () => {
           documentLoader,
           suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
           purpose: new CapabilityInvocation({
-            capability: did,
+            capability: helpers.generatateRootZcapId({id: did}),
             capabilityAction,
             invocationTarget: mockOperation.record.id
           })
@@ -413,7 +413,7 @@ describe.only('validate regular DIDs', () => {
           documentLoader,
           suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
           purpose: new CapabilityInvocation({
-            capability: did,
+            capability: helpers.generatateRootZcapId({id: did}),
             capabilityAction,
             invocationTarget: mockOperation.record.id
           })
@@ -456,7 +456,7 @@ describe.only('validate regular DIDs', () => {
           documentLoader,
           suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
           purpose: new CapabilityInvocation({
-            capability: did,
+            capability: helpers.generatateRootZcapId({id: did}),
             capabilityAction,
             invocationTarget: mockOperation.record.id
           })
@@ -506,7 +506,7 @@ describe.only('validate regular DIDs', () => {
           documentLoader,
           suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
           purpose: new CapabilityInvocation({
-            capability: did,
+            capability: helpers.generatateRootZcapId({id: did}),
             capabilityAction,
             invocationTarget: mockOperation.record.id
           })
@@ -549,7 +549,7 @@ describe.only('validate regular DIDs', () => {
           documentLoader,
           suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
           purpose: new CapabilityInvocation({
-            capability: did,
+            capability: helpers.generatateRootZcapId({id: did}),
             capabilityAction,
             invocationTarget: mockOperation.record.id
           })
@@ -608,7 +608,7 @@ describe.only('validate regular DIDs', () => {
         documentLoader,
         suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
         purpose: new CapabilityInvocation({
-          capability: did,
+          capability: helpers.generatateRootZcapId({id: did}),
           capabilityAction,
           invocationTarget: did
         })
@@ -660,7 +660,7 @@ describe.only('validate regular DIDs', () => {
         documentLoader,
         suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
         purpose: new CapabilityInvocation({
-          capability: did,
+          capability: helpers.generatateRootZcapId({id: did}),
           capabilityAction,
           invocationTarget: did
         })
@@ -708,7 +708,7 @@ describe.only('validate regular DIDs', () => {
         documentLoader,
         suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
         purpose: new CapabilityInvocation({
-          capability: did,
+          capability: helpers.generatateRootZcapId({id: did}),
           capabilityAction,
           invocationTarget: did
         })
@@ -765,7 +765,7 @@ describe.only('validate regular DIDs', () => {
         documentLoader,
         suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
         purpose: new CapabilityInvocation({
-          capability: did,
+          capability: helpers.generatateRootZcapId({id: did}),
           capabilityAction,
           invocationTarget: did
         })
@@ -817,7 +817,7 @@ describe.only('validate regular DIDs', () => {
         documentLoader,
         suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
         purpose: new CapabilityInvocation({
-          capability: did,
+          capability: helpers.generatateRootZcapId({id: did}),
           capabilityAction,
           invocationTarget: did
         })
@@ -868,7 +868,7 @@ describe.only('validate regular DIDs', () => {
         documentLoader,
         suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
         purpose: new CapabilityInvocation({
-          capability: did,
+          capability: helpers.generatateRootZcapId({id: did}),
           capabilityAction,
           // Set the invocation target to did2 here
           // in order to have the correct expectedTarget in the validator below.
@@ -933,7 +933,7 @@ describe.only('validate regular DIDs', () => {
         documentLoader,
         suite: new Ed25519Signature2020({key: capabilityInvocationKey1}),
         purpose: new CapabilityInvocation({
-          capability: did,
+          capability: helpers.generatateRootZcapId({id: did}),
           capabilityAction,
           invocationTarget: did
         })
@@ -992,7 +992,7 @@ describe.only('validate regular DIDs', () => {
         documentLoader,
         suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
         purpose: new CapabilityInvocation({
-          capability: did,
+          capability: helpers.generatateRootZcapId({id: did}),
           capabilityAction,
           invocationTarget: did1
         })
@@ -1045,7 +1045,7 @@ describe.only('validate regular DIDs', () => {
         documentLoader,
         suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
         purpose: new CapabilityInvocation({
-          capability: did,
+          capability: helpers.generatateRootZcapId({id: did}),
           capabilityAction,
           invocationTarget: did
         })
@@ -1097,7 +1097,7 @@ describe.only('validate regular DIDs', () => {
         documentLoader,
         suite: new Ed25519Signature2020({key: newKey}),
         purpose: new CapabilityInvocation({
-          capability: did,
+          capability: helpers.generatateRootZcapId({id: did}),
           capabilityAction,
           invocationTarget: did
         })
@@ -1154,7 +1154,7 @@ describe.only('validate regular DIDs', () => {
         documentLoader,
         suite: new Ed25519Signature2020({key: newKey}),
         purpose: new CapabilityInvocation({
-          capability: did,
+          capability: helpers.generatateRootZcapId({id: did}),
           capabilityAction,
           invocationTarget: did
         })
@@ -1204,7 +1204,7 @@ describe.only('validate regular DIDs', () => {
         documentLoader,
         suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
         purpose: new CapabilityInvocation({
-          capability: did,
+          capability: helpers.generatateRootZcapId({id: did}),
           capabilityAction,
           invocationTarget: did
         })
@@ -1257,7 +1257,7 @@ describe.only('validate regular DIDs', () => {
         documentLoader,
         suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
         purpose: new CapabilityInvocation({
-          capability: did,
+          capability: helpers.generatateRootZcapId({id: did}),
           capabilityAction,
           invocationTarget: did
         })
@@ -1324,7 +1324,7 @@ describe.only('validate regular DIDs', () => {
           documentLoader,
           suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
           purpose: new CapabilityInvocation({
-            capability: did,
+            capability: helpers.generatateRootZcapId({id: did}),
             capabilityAction,
             invocationTarget: did
           })
@@ -1377,7 +1377,7 @@ describe.only('validate regular DIDs', () => {
           documentLoader,
           suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
           purpose: new CapabilityInvocation({
-            capability: did,
+            capability: helpers.generatateRootZcapId({id: did}),
             capabilityAction,
             invocationTarget: did
           })
@@ -1424,7 +1424,7 @@ describe.only('validate regular DIDs', () => {
           documentLoader,
           suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
           purpose: new CapabilityInvocation({
-            capability: did,
+            capability: helpers.generatateRootZcapId({id: did}),
             capabilityAction,
             invocationTarget: did
           })
@@ -1472,7 +1472,7 @@ describe.only('validate regular DIDs', () => {
           documentLoader,
           suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
           purpose: new CapabilityInvocation({
-            capability: did,
+            capability: helpers.generatateRootZcapId({id: did}),
             capabilityAction,
             invocationTarget: did
           })
@@ -1529,7 +1529,7 @@ describe.only('validate regular DIDs', () => {
           documentLoader,
           suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
           purpose: new CapabilityInvocation({
-            capability: did,
+            capability: helpers.generatateRootZcapId({id: did}),
             capabilityAction,
             invocationTarget: did
           })

--- a/test/mocha/05-validate-async.js
+++ b/test/mocha/05-validate-async.js
@@ -39,7 +39,7 @@ describe.only('validate regular DIDs', () => {
   });
   describe('Create Operations', () => {
     it('validates a proper CreateWebLedgerRecord operation', async () => {
-      const {did, mockDoc, capabilityInvocationKey} = await _generateDid();
+      const {mockDoc, capabilityInvocationKey} = await _generateDid();
       const mockOperation = clone(mockData.operations.create);
       const capabilityAction = 'write';
       mockOperation.record = mockDoc;
@@ -50,7 +50,7 @@ describe.only('validate regular DIDs', () => {
         documentLoader,
         suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
         purpose: new CapabilityInvocation({
-          capability: helpers.generatateRootZcapId({id: did}),
+          capability: helpers.generatateRootZcapId({id: mockDoc.id}),
           capabilityAction,
           invocationTarget: mockDoc.id
         })

--- a/test/mocha/05-validate-async.js
+++ b/test/mocha/05-validate-async.js
@@ -16,11 +16,12 @@ const voValidator = require('veres-one-validator');
 const {CapabilityInvocation} = require('@digitalbazaar/zcapld');
 const mockData = require('./mock.data');
 const {VeresOneDidDoc} = require('did-veres-one');
+const helpers = require('./helpers');
 const v1 = require('did-veres-one').driver({mode: 'test'});
 
 const {util: {clone}} = bedrock;
 
-describe('validate regular DIDs', () => {
+describe.only('validate regular DIDs', () => {
   describe('validate API', () => {
     it('throws on missing ledgerNode parameter', async () => {
       let result;
@@ -49,7 +50,7 @@ describe('validate regular DIDs', () => {
         documentLoader,
         suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
         purpose: new CapabilityInvocation({
-          capability: did,
+          capability: helpers.generatateRootZcapId({id: did}),
           capabilityAction,
           invocationTarget: mockDoc.id
         })

--- a/test/mocha/12-validate-ledger-configuration.js
+++ b/test/mocha/12-validate-ledger-configuration.js
@@ -11,9 +11,10 @@ const voValidator = require('veres-one-validator');
 const v1 = require('did-veres-one').driver({mode: 'test'});
 const {Ed25519Signature2020} =
   require('@digitalbazaar/ed25519-signature-2020');
-const {purposes: {AssertionProofPurpose}} = jsigs;
+const {CapabilityInvocation} = require('@digitalbazaar/zcapld');
+const helpers = require('./helpers');
 
-describe('validate API WebLedgerConfiguration', () => {
+describe.only('validate API WebLedgerConfiguration', () => {
   it('should validate a ledgerConfiguration', async () => {
     const ledgerConfiguration = clone(mockData.ledgerConfigurations.alpha);
 
@@ -24,10 +25,14 @@ describe('validate API WebLedgerConfiguration', () => {
       maintainerDoc.methodFor({purpose: 'capabilityInvocation'});
 
     const s = await jsigs.sign(ledgerConfiguration, {
-      compactProof: false,
       documentLoader,
       suite: new Ed25519Signature2020({key: signingKey}),
-      purpose: new AssertionProofPurpose()
+      purpose: new CapabilityInvocation({
+        capability: helpers.generatateRootZcapId(
+          {id: ledgerConfiguration.ledger}),
+        capabilityAction: 'write',
+        invocationTarget: `${ledgerConfiguration.ledger}/config`
+      })
     });
 
     const result = await voValidator.validate({
@@ -52,7 +57,12 @@ describe('validate API WebLedgerConfiguration', () => {
       compactProof: false,
       documentLoader,
       suite: new Ed25519Signature2020({key: signingKey}),
-      purpose: new AssertionProofPurpose()
+      purpose: new CapabilityInvocation({
+        capability: helpers.generatateRootZcapId(
+          {id: ledgerConfiguration.ledger}),
+        capabilityAction: 'write',
+        invocationTarget: `${ledgerConfiguration.ledger}/config`
+      })
     });
 
     const result = await voValidator.validate({
@@ -79,7 +89,12 @@ describe('validate API WebLedgerConfiguration', () => {
       compactProof: false,
       documentLoader,
       suite: new Ed25519Signature2020({key: signingKey}),
-      purpose: new AssertionProofPurpose()
+      purpose: new CapabilityInvocation({
+        capability: helpers.generatateRootZcapId(
+          {id: ledgerConfiguration.ledger}),
+        capabilityAction: 'write',
+        invocationTarget: `${ledgerConfiguration.ledger}/config`
+      })
     });
 
     const result = await voValidator.validate({
@@ -104,7 +119,12 @@ describe('validate API WebLedgerConfiguration', () => {
       compactProof: false,
       documentLoader,
       suite: new Ed25519Signature2020({key: signingKey}),
-      purpose: new AssertionProofPurpose()
+      purpose: new CapabilityInvocation({
+        capability: helpers.generatateRootZcapId(
+          {id: ledgerConfiguration.ledger}),
+        capabilityAction: 'write',
+        invocationTarget: `${ledgerConfiguration.ledger}/config`
+      })
     });
     // replace the proof with a bad one
     s.proof.proofValue = 'z2p7cVPKsvUHzSfMQxziNPmzE7xx5nVHDZG1ZWYCk41gQJxxYr' +
@@ -131,7 +151,12 @@ describe('validate API WebLedgerConfiguration', () => {
       compactProof: false,
       documentLoader,
       suite: new Ed25519Signature2020({key: signingKey}),
-      purpose: new AssertionProofPurpose()
+      purpose: new CapabilityInvocation({
+        capability: helpers.generatateRootZcapId(
+          {id: ledgerConfiguration.ledger}),
+        capabilityAction: 'write',
+        invocationTarget: `${ledgerConfiguration.ledger}/config`
+      })
     });
     s.proof.verificationMethod =
       'did:v1:test:nym:z6MknbD3kDazNR5K5Aj9HtxsaqS1s2NUcTxescFdvZryECFx#' +
@@ -162,7 +187,12 @@ describe('validate API WebLedgerConfiguration', () => {
       compactProof: false,
       documentLoader,
       suite: new Ed25519Signature2020({key: signingKey}),
-      purpose: new AssertionProofPurpose()
+      purpose: new CapabilityInvocation({
+        capability: helpers.generatateRootZcapId(
+          {id: ledgerConfiguration.ledger}),
+        capabilityAction: 'write',
+        invocationTarget: `${ledgerConfiguration.ledger}/config`
+      })
     });
 
     s.proof.verificationMethod =

--- a/test/mocha/12-validate-ledger-configuration.js
+++ b/test/mocha/12-validate-ledger-configuration.js
@@ -14,8 +14,8 @@ const {Ed25519Signature2020} =
 const {CapabilityInvocation} = require('@digitalbazaar/zcapld');
 const helpers = require('./helpers');
 
-describe.only('validate API WebLedgerConfiguration', () => {
-  it.only('should validate a ledgerConfiguration', async () => {
+describe('validate API WebLedgerConfiguration', () => {
+  it('should validate a ledgerConfiguration', async () => {
     const ledgerConfiguration = clone(mockData.ledgerConfigurations.alpha);
 
     // The public key material is derived from the nym DID because the

--- a/test/mocha/12-validate-ledger-configuration.js
+++ b/test/mocha/12-validate-ledger-configuration.js
@@ -31,10 +31,9 @@ describe.only('validate API WebLedgerConfiguration', () => {
         capability: helpers.generatateRootZcapId(
           {id: ledgerConfiguration.ledger}),
         capabilityAction: 'write',
-        invocationTarget: `${ledgerConfiguration.ledger}/config`
+        invocationTarget: `${ledgerConfiguration.ledger}`
       })
     });
-
     const result = await voValidator.validate({
       ledgerNode: mockData.ledgerNode,
       validatorInput: s,

--- a/test/mocha/12-validate-ledger-configuration.js
+++ b/test/mocha/12-validate-ledger-configuration.js
@@ -15,21 +15,20 @@ const {CapabilityInvocation} = require('@digitalbazaar/zcapld');
 const helpers = require('./helpers');
 
 describe.only('validate API WebLedgerConfiguration', () => {
-  it('should validate a ledgerConfiguration', async () => {
+  it.only('should validate a ledgerConfiguration', async () => {
     const ledgerConfiguration = clone(mockData.ledgerConfigurations.alpha);
 
     // The public key material is derived from the nym DID because the
     // maintainers DID does not yet exist on the ledger
-    const maintainerDoc = await v1.generate();
-    const signingKey =
-      maintainerDoc.methodFor({purpose: 'capabilityInvocation'});
+    const {methodFor, didDocument} = await v1.generate();
+    const signingKey = methodFor({purpose: 'capabilityInvocation'});
 
     const s = await jsigs.sign(ledgerConfiguration, {
       documentLoader,
       suite: new Ed25519Signature2020({key: signingKey}),
       purpose: new CapabilityInvocation({
         capability: helpers.generatateRootZcapId(
-          {id: ledgerConfiguration.ledger}),
+          {id: ledgerConfiguration.ledger, controller: didDocument.id}),
         capabilityAction: 'write',
         invocationTarget: `${ledgerConfiguration.ledger}`
       })

--- a/test/mocha/12-validate-ledger-configuration.js
+++ b/test/mocha/12-validate-ledger-configuration.js
@@ -22,7 +22,6 @@ describe.only('validate API WebLedgerConfiguration', () => {
     // maintainers DID does not yet exist on the ledger
     const {methodFor, didDocument} = await v1.generate();
     const signingKey = methodFor({purpose: 'capabilityInvocation'});
-
     const s = await jsigs.sign(ledgerConfiguration, {
       documentLoader,
       suite: new Ed25519Signature2020({key: signingKey}),

--- a/test/mocha/15-validate-witness-pool.js
+++ b/test/mocha/15-validate-witness-pool.js
@@ -41,13 +41,11 @@ describe('validate API WitnessPool', () => {
         operation = await attachInvocationProof({
           operation,
           // capability: maintainerDid,
-          capability: witnessPoolDoc.id,
+          capability: helpers.generatateRootZcapId({id: witnessPoolDoc.id}),
           capabilityAction: 'write',
-          invocationTarget: operation.record.id,
+          invocationTarget: witnessPoolDoc.id,
           key,
-          signer: key.signer()
         });
-
         // FIXME: attach proof instead of mock proof above
         // operation = await attachInvocationProof(operation, {
         //   capability: maintainerDid,

--- a/test/mocha/15-validate-witness-pool.js
+++ b/test/mocha/15-validate-witness-pool.js
@@ -37,11 +37,13 @@ describe('validate API WitnessPool', () => {
         // FIXME: add a write proof for the ledger that will pass json-schema
         // validation for testnet v2 *not* a valid signature
         operation.proof = bedrock.util.clone(mockData.proof);
-
         operation = await attachInvocationProof({
           operation,
-          // capability: maintainerDid,
-          capability: helpers.generatateRootZcapId({id: witnessPoolDoc.id}),
+          capability: helpers.generatateRootZcapId({
+            id: witnessPoolDoc.id,
+            // this is not a didDoc so the controller should be the maintainer
+            controller: key.id
+          }),
           capabilityAction: 'write',
           invocationTarget: witnessPoolDoc.id,
           key,
@@ -426,8 +428,11 @@ describe('validate API WitnessPool', () => {
 
         operation = await attachInvocationProof({
           operation,
-          capability: witnessPoolDoc.id,
-          // capabilityAction: operation.type,
+          capability: helpers.generatateRootZcapId({
+            id: witnessPoolDoc.id,
+            // this is not a didDoc so the controller should be the maintainer
+            controller: key.id
+          }),
           capabilityAction: 'write',
           invocationTarget: operation.recordPatch.target,
           key,
@@ -505,8 +510,11 @@ describe('validate API WitnessPool', () => {
 
         operation = await attachInvocationProof({
           operation,
-          capability: witnessPoolDoc.id,
-          // capabilityAction: operation.type,
+          capability: helpers.generatateRootZcapId({
+            id: witnessPoolDoc.id,
+            // this is not a didDoc so the controller should be the maintainer
+            controller: key.id
+          }),
           capabilityAction: 'write',
           invocationTarget: operation.recordPatch.target,
           key,

--- a/test/mocha/17-validate-validator-parameter-set.js
+++ b/test/mocha/17-validate-validator-parameter-set.js
@@ -42,8 +42,10 @@ describe('validate API ValidatorParameterSet', () => {
 
         operation = await attachInvocationProof({
           operation,
-          // capability: maintainerDid,
-          capability: validatorParameterSetDoc.id,
+          capability: helpers.generatateRootZcapId({
+            id: operation.record.id,
+            controller: key.id
+          }),
           capabilityAction: 'write',
           invocationTarget: operation.record.id,
           key,
@@ -91,8 +93,10 @@ describe('validate API ValidatorParameterSet', () => {
 
         operation = await attachInvocationProof({
           operation,
-          // capability: maintainerDid,
-          capability: validatorParameterSetDoc.id,
+          capability: helpers.generatateRootZcapId({
+            id: operation.record.id,
+            controller: key.id
+          }),
           capabilityAction: 'write',
           invocationTarget: operation.record.id,
           key,
@@ -148,8 +152,10 @@ describe('validate API ValidatorParameterSet', () => {
 
         operation = await attachInvocationProof({
           operation,
-          // capability: maintainerDid,
-          capability: validatorParameterSetDoc.id,
+          capability: helpers.generatateRootZcapId({
+            id: operation.record.id,
+            controller: key.id
+          }),
           capabilityAction: 'write',
           invocationTarget: operation.record.id,
           key,
@@ -226,8 +232,10 @@ describe('validate API ValidatorParameterSet', () => {
 
         operation = await attachInvocationProof({
           operation,
-          capability: validatorParameterSetDoc.id,
-          // capabilityAction: operation.type,
+          capability: helpers.generatateRootZcapId({
+            id: operation.recordPatch.target,
+            controller: key.id
+          }),
           capabilityAction: 'write',
           invocationTarget: operation.recordPatch.target,
           key,
@@ -298,8 +306,10 @@ describe('validate API ValidatorParameterSet', () => {
 
         operation = await attachInvocationProof({
           operation,
-          capability: validatorParameterSetDoc.id,
-          // capabilityAction: operation.type,
+          capability: helpers.generatateRootZcapId({
+            id: operation.recordPatch.target,
+            controller: key.id
+          }),
           capabilityAction: 'write',
           invocationTarget: operation.recordPatch.target,
           key,
@@ -374,8 +384,10 @@ describe('validate API ValidatorParameterSet', () => {
 
         operation = await attachInvocationProof({
           operation,
-          capability: validatorParameterSetDoc.id,
-          // capabilityAction: operation.type,
+          capability: helpers.generatateRootZcapId({
+            id: operation.recordPatch.target,
+            controller: key.id
+          }),
           capabilityAction: 'write',
           invocationTarget: operation.recordPatch.target,
           key,
@@ -449,8 +461,10 @@ describe('validate API ValidatorParameterSet', () => {
         operation.proof = clone(mockData.proof);
         operation = await attachInvocationProof({
           operation,
-          capability: validatorParameterSetDoc.id,
-          // capabilityAction: operation.type,
+          capability: helpers.generatateRootZcapId({
+            id: operation.recordPatch.target,
+            controller: key.id
+          }),
           capabilityAction: 'write',
           invocationTarget: operation.recordPatch.target,
           key,

--- a/test/mocha/helpers.js
+++ b/test/mocha/helpers.js
@@ -4,8 +4,7 @@
 'use strict';
 
 const bedrock = require('bedrock');
-const {util: {clone, BedrockError}} = bedrock;
-const {CONTEXT_URL: ZCAP_CONTEXT_URL} = require('zcap-context');
+const {config: {constants}, util: {clone, BedrockError}} = bedrock;
 const {jsonLdDocumentLoader} = require('bedrock-jsonld-document-loader');
 
 exports.createMockLedgerNode = ({ldDocuments}) => {
@@ -45,7 +44,7 @@ exports.createMockLedgerNode = ({ldDocuments}) => {
 exports.generatateRootZcapId = ({id}) => {
   const zcapId = `urn:zcap:root:${encodeURIComponent(id)}`;
   const zcap = {
-    '@context': ZCAP_CONTEXT_URL,
+    '@context': constants.ZCAP_CONTEXT_V1_URL,
     id: zcapId,
     controller: id,
     invocationTarget: id

--- a/test/mocha/helpers.js
+++ b/test/mocha/helpers.js
@@ -5,6 +5,7 @@
 
 const bedrock = require('bedrock');
 const {util: {clone, BedrockError}} = bedrock;
+const {documentLoader} = require('bedrock-jsonld-document-loader');
 
 exports.createMockLedgerNode = ({ldDocuments}) => {
   return {
@@ -30,4 +31,17 @@ exports.createMockLedgerNode = ({ldDocuments}) => {
       }
     }
   };
+};
+
+/**
+ * Takes in an id and generates a urn for the root zcap dynamically.
+ *
+ * @param {object} options - Options to use.
+ * @param {string} options.id - Either a UUID or a DiD.
+ *
+ * @returns {string} The resulting zcap id.
+ */
+exports.generatateRootZcapId = ({id}) => {
+  const zcapId = `urn:zcap:root:${encodeURIComponent(id)}`;
+  return zcapId;
 };

--- a/test/mocha/helpers.js
+++ b/test/mocha/helpers.js
@@ -41,12 +41,12 @@ exports.createMockLedgerNode = ({ldDocuments}) => {
  *
  * @returns {string} The resulting zcap id.
  */
-exports.generatateRootZcapId = ({id}) => {
+exports.generatateRootZcapId = ({id, controller}) => {
   const zcapId = `urn:zcap:root:${encodeURIComponent(id)}`;
   const zcap = {
     '@context': constants.ZCAP_CONTEXT_V1_URL,
     id: zcapId,
-    controller: id,
+    controller: controller || id,
     invocationTarget: id
   };
   jsonLdDocumentLoader.addStatic(zcapId, zcap);

--- a/test/mocha/helpers.js
+++ b/test/mocha/helpers.js
@@ -5,7 +5,8 @@
 
 const bedrock = require('bedrock');
 const {util: {clone, BedrockError}} = bedrock;
-const {documentLoader} = require('bedrock-jsonld-document-loader');
+const {CONTEXT_URL: ZCAP_CONTEXT_URL} = require('zcap-context');
+const {jsonLdDocumentLoader} = require('bedrock-jsonld-document-loader');
 
 exports.createMockLedgerNode = ({ldDocuments}) => {
   return {
@@ -43,5 +44,12 @@ exports.createMockLedgerNode = ({ldDocuments}) => {
  */
 exports.generatateRootZcapId = ({id}) => {
   const zcapId = `urn:zcap:root:${encodeURIComponent(id)}`;
+  const zcap = {
+    '@context': ZCAP_CONTEXT_URL,
+    id: zcapId,
+    controller: id,
+    invocationTarget: id
+  };
+  jsonLdDocumentLoader.addStatic(zcapId, zcap);
   return zcapId;
 };

--- a/test/mocha/mock.data.js
+++ b/test/mocha/mock.data.js
@@ -224,7 +224,10 @@ mock.authorizedSigners = {
 };
 
 ledgerConfigurations.alpha = {
-  '@context': constants.WEB_LEDGER_CONTEXT_V1_URL,
+  '@context': [
+    constants.WEB_LEDGER_CONTEXT_V1_URL,
+    constants.ZCAP_CONTEXT_V1_URL
+  ],
   type: 'WebLedgerConfiguration',
   ledger: 'did:v1:c02915fc-672d-4568-8e6e-b12a0b35cbb3',
   consensusMethod: 'Continuity2017',

--- a/test/mocha/mock.data.js
+++ b/test/mocha/mock.data.js
@@ -4,6 +4,8 @@
 'use strict';
 
 const bedrock = require('bedrock');
+const helpers = require('./helpers');
+
 const {config: {constants}, util: {uuid, BedrockError}} = bedrock;
 
 const mock = {};
@@ -44,7 +46,9 @@ const validatorParameterSet = mock.validatorParameterSet = {};
 mock.proof = {
   type: 'Ed25519Signature2020',
   created: '2021-01-10T23:10:25Z',
-  capability: 'did:v1:test:uuid:c37e914a-1e2a-4d59-9668-ee93458fd19a',
+  capability: helpers.generatateRootZcapId({
+    id: 'did:v1:test:uuid:c37e914a-1e2a-4d59-9668-ee93458fd19a'
+  }),
   capabilityAction: 'write',
   invocationTarget:
     'did:v1:nym:z6Mkogv718iDZqyoTmPKagKcG2VBXXz6w4xau8fL5jjB948r',

--- a/test/mocha/mock.data.js
+++ b/test/mocha/mock.data.js
@@ -51,7 +51,7 @@ mock.proof = {
   }),
   capabilityAction: 'write',
   invocationTarget:
-    'did:v1:nym:z6Mkogv718iDZqyoTmPKagKcG2VBXXz6w4xau8fL5jjB948r',
+    'did:v1:test:uuid:c37e914a-1e2a-4d59-9668-ee93458fd19a',
   proofPurpose: 'capabilityInvocation',
   proofValue: 'z3t9it5yhFHkqWnHKMQ2DWVj7aHDN37f95UzhQYQGYd9LyTSGzufCiTwDWN' +
     'fCdxQA9ZHcTTVAhHwoAji2AJnk2E6',

--- a/test/package.json
+++ b/test/package.json
@@ -34,7 +34,8 @@
     "jsonld-signatures": "^9.0.2",
     "nyc": "^15.1.0",
     "veres-one-validator": "file:..",
-    "x25519-key-agreement-2020-context": "^1.0.0"
+    "x25519-key-agreement-2020-context": "^1.0.0",
+    "zcap-context": "^1.2.1"
   },
   "devDependencies": {
     "@digitalbazaar/ed25519-signature-2020": "^3.0.0",


### PR DESCRIPTION
1. adds a new util for generating root zcaps dynamically
2. Updates tests to use new root zcap feature
3. Updates proofs for `CreateWebLedgerRecords` and `UpdateWebLedgerRecord` to expect new zcaps
4. Changes the validator for `LedgerConfig` to use `CapabilityInvocation` instead of `AssertionPurpose`
5. Adds zcap context to ledgerConfig validator
6. Updates assertions for some tests and also makes corrections to  a few tests (such as using a ledger id)

NOTE: this pr does not contain the `caveats` such as `/records` or `/config`.

Tasks

- [x] Review code and see if any untested functionality needs to be changed
- [x] Test this branch in veres-one with did-bench-cli
- [x] Update did-bench-cli and veres-one-maintainer-cli to use newer zcap creation
- [x] Add issues for tests that are broken / skipped
- [x] Add issue for adding validation to ledgerWrite (not record write) proofs as we now have code similar to them
- [ ] Add CHANGELOG entry (this is probably a major release)
- [ ] Update peerDeps for major release

UNFINISHED DON'T MERGE
This PR awaits this PR: https://github.com/veres-one/veres-one-validator/pull/42
Also please note this PR has typos in it corrected in https://github.com/veres-one/veres-one-validator/pull/42

TODO:

- [x] A way of determining the controller of the rootZcap must be determined
- [x] [See this example in ezcap-express for an example](https://github.com/digitalbazaar/ezcap-express/blob/bee523acfc46c599c0253c89d324b5b2dd562a26/README.md#define-getrootcontroller)
- [x] Use `veres-one`'s test project to test this